### PR TITLE
修复 trigger(action 为 hover 时) 中有另一个 trigger 时，如果移动到里面 trigger 的 popup 时会使外面的 popup 消失

### DIFF
--- a/examples/nested.js
+++ b/examples/nested.js
@@ -34,10 +34,23 @@ const builtinPlacements = {
 
 const Test = React.createClass({
   render() {
+    const me = this;
+    const innerTrigger = (<div>
+      <div ref="container"></div>
+      <Trigger
+        popupPlacement="bottom"
+        action={['click']}
+        builtinPlacements={builtinPlacements}
+        getPopupContainer={() => {return me.refs.container;}}
+        popup={<div style={{ border: '1px solid red', padding: 10 }}>I am inner Trigger Popup</div>}
+      >
+        <span href="#" style={{ margin: 20 }}>clickToShowInnerTrigger</span>
+      </Trigger>
+    </div>);
     return (
       <div>
         <Trigger
-          popupPlacement="right"
+          popupPlacement="left"
           action={['click']}
           builtinPlacements={builtinPlacements}
           popup={<div style={{ border: '1px solid red', padding: 10 }}>i am a click popup</div>}
@@ -50,6 +63,14 @@ const Test = React.createClass({
           >
             <span href="#" style={{ margin: 20 }}>trigger</span>
           </Trigger>
+        </Trigger>
+        <Trigger
+          popupPlacement="right"
+          action={['hover']}
+          builtinPlacements={builtinPlacements}
+          popup={innerTrigger}
+        >
+          <span href="#" style={{ margin: 20 }}>trigger</span>
         </Trigger>
       </div>
     );

--- a/src/Trigger.jsx
+++ b/src/Trigger.jsx
@@ -152,8 +152,12 @@ const Trigger = React.createClass({
     this.delaySetPopupVisible(true, this.props.mouseEnterDelay);
   },
 
-  onMouseLeave() {
-    this.delaySetPopupVisible(false, this.props.mouseLeaveDelay);
+  onMouseLeave(e) {
+    const relatedTarget = e.relatedTarget;
+    const popupContainer = this.getPopupContainer();
+    if (relatedTarget === window || !popupContainer.contains(relatedTarget)) {
+      this.delaySetPopupVisible(false, this.props.mouseLeaveDelay);
+    }
   },
 
   onFocus() {

--- a/tests/index.js
+++ b/tests/index.js
@@ -227,7 +227,6 @@ describe('rc-trigger', function main() {
       }], done);
     });
   });
-
   describe('placement', () => {
     it('left works', (done) => {
       const trigger = ReactDOM.render((


### PR DESCRIPTION
related issue: https://github.com/react-component/tooltip/issues/44
based on: https://github.com/facebook/react/blob/master/src/renderers/dom/client/eventPlugins/EnterLeaveEventPlugin.js
> I try to write a test case to handle this problem，but failed，seems React test utils cannot reproduce，this is my test case

```
it('mouse enter inner trigger popup should not hide outer trigger popup', (done) => {
      const Test2 = React.createClass({
        render() {
          const me = this;
          const innerTrigger = <div>
            <div ref="container"></div>
            <Trigger
              ref="innerTrigger"
              popupAlign={placementAlignMap.left}
              action={['click']}
              getPopupContainer={() => {return me.refs.container}}
              popup={<div style={{ border: '1px solid red', padding: 10 }}> I am inner Trigger Popup</div>}
            >
              <span href="#" className="innerTrigger" style={{ margin: 20 }}>clickToShowInnerTrigger</span>
            </Trigger>
          </div>;
          return (
            <Trigger
              ref="outerTrigger"
              popupAlign={placementAlignMap.left}
              action={['hover']}
              popup={innerTrigger}
            >
            <div href="#" className="target" style={{ margin: 20 }}>trigger</div>
          </Trigger> 
          );
        },
      });
      const trigger = ReactDOM.render(<Test2 />, div);
      const target = scryRenderedDOMComponentsWithClass(trigger, 'target')[0];
      Simulate.mouseEnter(target);
      async.series([timeout(100), (next) => {
        const outerPopupDOMNode = trigger.refs.outerTrigger.getPopupDomNode();
        const innerTrigger = trigger.refs.innerTrigger;
        const innerTriggerTarget = scryRenderedDOMComponentsWithClass(innerTrigger, 'innerTrigger')[0];
        Simulate.click(innerTriggerTarget);
        next()
      }, timeout(100), (next) => {
        const outerPopupDOMNode = trigger.refs.outerTrigger.getPopupDomNode();
        const innerPopupDOMNode = trigger.refs.innerTrigger.getPopupDomNode();
        Simulate.click(innerPopupDOMNode);
        expect($(outerPopupDOMNode).css('display')).not.to.be('none');
        next();
      }], done);
    });
```

but I write a new example in nested.html to reproduce it.