### PR TITLE
Stop event propagation on click

### DIFF
--- a/src/Trigger.jsx
+++ b/src/Trigger.jsx
@@ -206,6 +206,7 @@ const Trigger = React.createClass({
     this.preClickTime = 0;
     this.preTouchTime = 0;
     event.preventDefault();
+    event.stopPropagation();
     const nextVisible = !this.state.popupVisible;
     if (this.isClickToHide() && !nextVisible || nextVisible && this.isClickToShow()) {
       this.setPopupVisible(!this.state.popupVisible);


### PR DESCRIPTION
When I introduced 'rc-tooltip' package, I found that clicking trigger element propagates the event to parent elements.  I think it is not expected behavior.