### PR TITLE
Allow render with popup as a function

### DIFF
--- a/src/Trigger.jsx
+++ b/src/Trigger.jsx
@@ -24,7 +24,10 @@ const Trigger = React.createClass({
     getPopupClassNameFromAlign: PropTypes.any,
     onPopupVisibleChange: PropTypes.func,
     afterPopupVisibleChange: PropTypes.func,
-    popup: PropTypes.node.isRequired,
+    popup: PropTypes.oneOfType([
+      PropTypes.node,
+      PropTypes.func,
+    ]).isRequired,
     popupStyle: PropTypes.object,
     prefixCls: PropTypes.string,
     popupClassName: PropTypes.string,
@@ -292,7 +295,7 @@ const Trigger = React.createClass({
       maskAnimation={props.maskAnimation}
       maskTransitionName={props.maskTransitionName}
     >
-      {props.popup}
+      {typeof props.popup === 'function' ? props.popup.call() : props.popup}
     </Popup>);
   },
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -156,6 +156,37 @@ describe('rc-trigger', function main() {
       }], done);
     });
 
+    it('click works with function', (done) => {
+      let rendered = 42;
+      const popup = function renderPopup() {
+        rendered += 2;
+        return <strong className="x-content">tooltip3</strong>;
+      };
+      const trigger = ReactDOM.render((
+        <Trigger
+          action={['click']}
+          popupAlign={placementAlignMap.left}
+          popup={popup}
+        >
+          <div className="target">click</div>
+        </Trigger>), div);
+      expect(rendered).to.be(42);
+      const domNode = ReactDOM.findDOMNode(trigger);
+      Simulate.click(domNode);
+      async.series([timeout(20), (next) => {
+        const popupDomNode = trigger.getPopupDomNode();
+        expect(rendered).to.be(44);
+        expect($(popupDomNode).find('.x-content').html()).to.be('tooltip3');
+        expect(popupDomNode).to.be.ok();
+        Simulate.click(domNode);
+        next();
+      }, timeout(20), (next) => {
+        const popupDomNode = trigger.getPopupDomNode();
+        expect($(popupDomNode).css('display')).to.be('none');
+        next();
+      }], done);
+    });
+
     it('hover works', (done) => {
       const trigger = ReactDOM.render((
         <Trigger


### PR DESCRIPTION
This allow Trigger to render a popup as a function. It's particularly useful when you have hundreds of elements with tooltips and you don't want to generate all tooltips before they're triggered.

After merging this, I'll do the appropriate pull request on rc-tooltip to get the benefit of it.