### PR TITLE
fix getPopupDomNode

### DIFF
--- a/src/Trigger.jsx
+++ b/src/Trigger.jsx
@@ -222,7 +222,10 @@ const Trigger = React.createClass({
 
   getPopupDomNode() {
     // for test
-    return this.popupInstance.isMounted() ? this.popupInstance.getPopupDomNode() : null;
+    if (this.popupInstance) {
+      return this.popupInstance.isMounted() ? this.popupInstance.getPopupDomNode() : null;
+    }
+    return null;
   },
 
   getRootDomNode() {


### PR DESCRIPTION
没有popup时，直接调用 isMounted() 会报错