### PR TITLE
把 getComponent 定义在组件上

### DIFF
--- a/src/Trigger.jsx
+++ b/src/Trigger.jsx
@@ -67,40 +67,6 @@ const Trigger = React.createClass({
         mountNode.appendChild(popupContainer);
         return popupContainer;
       },
-
-      getComponent(instance) {
-        const { props, state } = instance;
-        const mouseProps = {};
-        if (instance.isMouseEnterToShow()) {
-          mouseProps.onMouseEnter = instance.onPopupMouseEnter;
-        }
-        if (instance.isMouseLeaveToHide()) {
-          mouseProps.onMouseLeave = instance.onPopupMouseLeave;
-        }
-        return (
-          <Popup
-            prefixCls={props.prefixCls}
-            destroyPopupOnHide={props.destroyPopupOnHide}
-            visible={state.popupVisible}
-            className={props.popupClassName}
-            action={props.action}
-            align={instance.getPopupAlign()}
-            onAlign={props.onPopupAlign}
-            animation={props.popupAnimation}
-            getClassNameFromAlign={instance.getPopupClassNameFromAlign}
-            {...mouseProps}
-            getRootDomNode={instance.getRootDomNode}
-            style={props.popupStyle}
-            mask={props.mask}
-            zIndex={props.zIndex}
-            transitionName={props.popupTransitionName}
-            maskAnimation={props.maskAnimation}
-            maskTransitionName={props.maskTransitionName}
-          >
-            {typeof props.popup === 'function' ? props.popup() : props.popup}
-          </Popup>
-        );
-      },
     }),
   ],
 
@@ -323,6 +289,40 @@ const Trigger = React.createClass({
       return getAlignFromPlacement(builtinPlacements, popupPlacement, popupAlign);
     }
     return popupAlign;
+  },
+
+  getComponent() {
+    const { props, state } = this;
+    const mouseProps = {};
+    if (this.isMouseEnterToShow()) {
+      mouseProps.onMouseEnter = this.onPopupMouseEnter;
+    }
+    if (this.isMouseLeaveToHide()) {
+      mouseProps.onMouseLeave = this.onPopupMouseLeave;
+    }
+    return (
+      <Popup
+        prefixCls={props.prefixCls}
+        destroyPopupOnHide={props.destroyPopupOnHide}
+        visible={state.popupVisible}
+        className={props.popupClassName}
+        action={props.action}
+        align={this.getPopupAlign()}
+        onAlign={props.onPopupAlign}
+        animation={props.popupAnimation}
+        getClassNameFromAlign={this.getPopupClassNameFromAlign}
+        {...mouseProps}
+        getRootDomNode={this.getRootDomNode}
+        style={props.popupStyle}
+        mask={props.mask}
+        zIndex={props.zIndex}
+        transitionName={props.popupTransitionName}
+        maskAnimation={props.maskAnimation}
+        maskTransitionName={props.maskTransitionName}
+      >
+        {typeof props.popup === 'function' ? props.popup() : props.popup}
+      </Popup>
+    );
   },
 
   setPopupVisible(popupVisible) {


### PR DESCRIPTION
这样调整可以方便写 Trigger 的测试，以 rc-select 的测试为例：

```javascript
const wrapper = mount(
  <Select>
    <Option value="1">1</Option>
  </Select>
);

wrapper.find('.rc-select').simulate('click');
// 现在是找不到 MenuItem 的，因为被渲染到另外一个 container 上去了
wrapper.find('MenuItem');
```

如果把 getComponent 定义成 Trigger 的实例方法，就可以这样做：

```javascript
// 首先 mock 掉 ReactDOM 的 `unstable_renderSubtreeIntoContainer`
// 然后就可以自己手工去 mount Trigger 里的组件

const dropdownWrapper = mount(wrapper.find('Trigger').node.getComponent());
dropdownWrapper.find('MenuItem'); // 可以正常找到了。
```

这个 PR 需要先合并  https://github.com/react-component/util/pull/8 