### PR TITLE
Fix duplicate versions of rc-util in bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
   "dependencies": {
     "babel-runtime": "6.x",
     "rc-align": "2.x",
-    "rc-animate": "2.x",
-    "rc-util": "4.x"
+    "rc-animate": "2.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rc-trigger",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "base abstract trigger component for react",
   "keywords": [
     "react",


### PR DESCRIPTION
Both rc-trigger and rc-align rely on rc-util but different versions, so end result is both version 3.x and 4.x are added to js bundle.

I've updated the rc-util version over in rc-align: https://github.com/react-component/align/pull/8

I've then removed rc-util as a dependency completely here in rc-trigger, since it is pulled in transitively. (Hope you are ok with that; it will help avoid this issue again in the future at least).