### PR TITLE
fix text auto layout bug

### DIFF
--- a/src/Trigger.jsx
+++ b/src/Trigger.jsx
@@ -65,8 +65,9 @@ const Trigger = React.createClass({
         // Make sure default popup container will never cause scrollbar appearing
         // https://github.com/react-component/trigger/issues/41
         popupContainer.style.position = 'absolute';
-        popupContainer.style.top = '-9999px';
-        popupContainer.style.left = '-9999px';
+        popupContainer.style.top = '0';
+        popupContainer.style.left = '0';
+        popupContainer.style.width = '100%';
         const mountNode = instance.props.getPopupContainer ?
           instance.props.getPopupContainer(findDOMNode(instance)) : document.body;
         mountNode.appendChild(popupContainer);

--- a/tests/index.js
+++ b/tests/index.js
@@ -622,4 +622,37 @@ describe('rc-trigger', function main() {
       });
     });
   }
+
+  describe('github issues', () => {
+    // https://github.com/ant-design/ant-design/issues/5047
+    // https://github.com/react-component/trigger/pull/43
+    it('render text without break lines', () => {
+      const trigger = ReactDOM.render(
+        <Trigger
+          popupVisible
+          popupAlign={placementAlignMap.top}
+          popup={<span>i am a pop up</span>}
+          popupClassName="no-fix-width"
+        >
+          <div>trigger</div>
+        </Trigger>
+      , div);
+      const popupNodeHeightOfSeveralWords = trigger.getPopupDomNode().offsetHeight;
+
+      const trigger2 = ReactDOM.render(
+        <Trigger
+          popupVisible
+          popupAlign={placementAlignMap.top}
+          popup={<span>iamapopup</span>}
+          popupClassName="no-fix-width"
+        >
+          <div>trigger</div>
+        </Trigger>
+      , div);
+      const popupNodeHeightOfOneWord = trigger2.getPopupDomNode().offsetHeight;
+
+      // height should be same, should not have break lines inside words
+      expect(popupNodeHeightOfOneWord).to.equal(popupNodeHeightOfSeveralWords);
+    });
+  });
 });

--- a/tests/test.less
+++ b/tests/test.less
@@ -2,6 +2,10 @@
   width: 100px;
 }
 
+.no-fix-width.rc-trigger-popup {
+  width: auto;
+}
+
 .target {
   width: 100px;
   height: 100px;


### PR DESCRIPTION
Will close https://github.com/ant-design/ant-design/issues/5047, fix bug introduced by #42 

---

负的 top 和 left 会使默认排版错乱。

改为 `top: 0; left: 0; width: 100%` 后正常。

## Demo

- Error: http://codepen.io/anon/pen/LWENYG?editors=0110
- Fixed: http://codepen.io/anon/pen/qrEZWO?editors=0110

## Screen Shots

<img width="308" alt="image" src="https://cloud.githubusercontent.com/assets/507615/23315551/9e0fdb8c-fb01-11e6-9e8d-950a4f00d55a.png">

<img width="170" alt="image" src="https://cloud.githubusercontent.com/assets/507615/23328850/88307492-fb66-11e6-98c7-4ddd3272b8f9.png">

<img width="572" alt="image" src="https://cloud.githubusercontent.com/assets/507615/23315615/f140b11e-fb01-11e6-8e75-7d7281319d72.png">

<img width="675" alt="image" src="https://cloud.githubusercontent.com/assets/507615/23315621/faa34bb8-fb01-11e6-9943-b9773ff59339.png">
