### PR TITLE
this.popupInstance should be this._component

### DIFF
--- a/src/Trigger.jsx
+++ b/src/Trigger.jsx
@@ -396,8 +396,8 @@ const Trigger = React.createClass({
     return action.indexOf('focus') !== -1 || hideAction.indexOf('blur') !== -1;
   },
   forcePopupAlign() {
-    if (this.state.popupVisible && this.popupInstance && this.popupInstance.alignInstance) {
-      this.popupInstance.alignInstance.forceAlign();
+    if (this.state.popupVisible && this._component && this._component.alignInstance) {
+      this._component.alignInstance.forceAlign();
     }
   },
 


### PR DESCRIPTION
After https://github.com/react-component/trigger/commit/5337b189c9af2f21768d44dde127ebfc6020f22e, `this.popupInstance` has renamed to `this._component`.

This PR fixes 
https://github.com/ant-design/ant-design/issues/6085 
https://github.com/react-component/tree-select/issues/51