### PR TITLE
Add Preact compabilitiy by checking if children is an array

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -392,12 +392,15 @@ const Trigger = createReactClass({
   },
 
   createTwoChains(event) {
-    const childPros = this.props.children.props;
+    const children = this.props.children;
+
+    const childProps = children instanceof Array ? children[0].props : children.props;
+
     const props = this.props;
-    if (childPros[event] && props[event]) {
+    if (childProps[event] && props[event]) {
       return this[`fire${event}`];
     }
-    return childPros[event] || props[event];
+    return childProps[event] || props[event];
   },
 
   isClickToShow() {

--- a/src/index.js
+++ b/src/index.js
@@ -439,7 +439,11 @@ const Trigger = createReactClass({
   },
 
   fireEvents(type, e) {
-    const childCallback = this.props.children.props[type];
+    const children = this.props.children;
+
+    const childProps = children instanceof Array ? children[0].props : children.props;
+
+    const childCallback = childProps[type];
     if (childCallback) {
       childCallback(e);
     }


### PR DESCRIPTION
this.props.children is an Array in Preact even if you only supply
one child to a component. This adds a check to see if the children
are an array. If they are, grab the props from the first one.

Also changes `childPros` to `childProps` to make it consistent
with the rest of the repo.

Close #66