### PR TITLE
Make rc-trigger compatible with Inferno/Preact

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -207,6 +207,7 @@ const Trigger = createReactClass({
     // react bug?
     if (e.relatedTarget && !e.relatedTarget.setTimeout &&
       this._component &&
+      this._component.getPopupDomNode &&
       contains(this._component.getPopupDomNode(), e.relatedTarget)) {
       return;
     }


### PR DESCRIPTION
When using Inferno instead of React, I'm getting the following error when closing a dropdown:

Uncaught TypeError: this._component.getPopupDomNode is not a function
    at Object.onPopupMouseLeave (index.js:178)

This change should fix the bug. I guess it's also related to https://github.com/ant-design/ant-design/issues/5701