### PR TITLE
Update transitionName props in readme to reflect they can also be an Object

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ import ReactDOM from 'react-dom';
 import Trigger from 'rc-trigger';
 
 ReactDOM.render((
-  <Trigger 
+  <Trigger
     action={['click']}
     popup={<span>popup</span>}
     popupAlign={{
@@ -139,13 +139,13 @@ ReactDOM.render((
         </tr>
         <tr>
           <td>popupTransitionName</td>
-          <td>String</td>
+          <td>String|Object</td>
           <td></td>
           <td>https://github.com/react-component/animate</td>
         </tr>
         <tr>
           <td>maskTransitionName</td>
-          <td>String</td>
+          <td>String|Object</td>
           <td></td>
           <td>https://github.com/react-component/animate</td>
         </tr>
@@ -220,13 +220,13 @@ ReactDOM.render((
           <td>string</td>
           <td></td>
           <td>use preset popup align config from builtinPlacements, can be merged by popupAlign prop</td>
-        </tr>   
+        </tr>
         <tr>
           <td>builtinPlacements</td>
           <td>object</td>
           <td></td>
           <td>builtin placement align map. used by placement prop</td>
-        </tr>        
+        </tr>
     </tbody>
 </table>
 


### PR DESCRIPTION
As per

https://github.com/react-component/trigger/blob/899e456b0d243a3b6da8960de9bf019b6ad52810/src/index.js#L65-L68

https://github.com/react-component/trigger/blob/899e456b0d243a3b6da8960de9bf019b6ad52810/src/index.js#L83-L86

`popupTransitionName` and `maskTransitionName`can be object as well as a string