### PR TITLE
Add close popup when click iframe for `click` trigger

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -160,6 +160,11 @@ export default class Trigger extends React.Component {
         this.clickOutsideHandler = addEventListener(currentDocument,
           'mousedown', this.onDocumentClick);
       }
+      // close popup when trigger type is `contextMenu`, or `click` and window is blurred
+      if (!this.clickBlurOutsideHandler && (this.isClickToHide() || this.isContextMenuToShow())) {
+        this.clickBlurOutsideHandler = addEventListener(window,
+          'blur', this.onDocumentClick);
+      }
       // always hide on mobile
       if (!this.touchOutsideHandler) {
         currentDocument = currentDocument || props.getDocument();
@@ -167,15 +172,10 @@ export default class Trigger extends React.Component {
           'touchstart', this.onDocumentClick);
       }
       // close popup when trigger type contains 'onContextMenu' and document is scrolling.
-      if (!this.contextMenuOutsideHandler1 && this.isContextMenuToShow()) {
+      if (!this.contextMenuScrollOutsideHandler && this.isContextMenuToShow()) {
         currentDocument = currentDocument || props.getDocument();
-        this.contextMenuOutsideHandler1 = addEventListener(currentDocument,
+        this.contextMenuScrollOutsideHandler = addEventListener(currentDocument,
           'scroll', this.onContextMenuClose);
-      }
-      // close popup when trigger type contains 'onContextMenu' and window is blur.
-      if (!this.contextMenuOutsideHandler2 && this.isContextMenuToShow()) {
-        this.contextMenuOutsideHandler2 = addEventListener(window,
-          'blur', this.onContextMenuClose);
       }
       return;
     }
@@ -465,14 +465,14 @@ export default class Trigger extends React.Component {
       this.clickOutsideHandler = null;
     }
 
-    if (this.contextMenuOutsideHandler1) {
-      this.contextMenuOutsideHandler1.remove();
-      this.contextMenuOutsideHandler1 = null;
+    if (this.contextMenuScrollOutsideHandler) {
+      this.contextMenuScrollOutsideHandler.remove();
+      this.contextMenuScrollOutsideHandler = null;
     }
 
-    if (this.contextMenuOutsideHandler2) {
-      this.contextMenuOutsideHandler2.remove();
-      this.contextMenuOutsideHandler2 = null;
+    if (this.clickBlurOutsideHandler) {
+      this.clickBlurOutsideHandler.remove();
+      this.clickBlurOutsideHandler = null;
     }
 
     if (this.touchOutsideHandler) {


### PR DESCRIPTION
Using Trigger with `contextMenu` supports closing on window blur, in order to cover when a user clicks/taps on an iframe, but when we use `click` as a trigger, this was previously not supported.

This fix modifies the handler to support both click and contextMenu as valid triggers.

* simulates document click on window blur for both click and contextMenu triggers
* `contextMenuOutsideHandler1` renamed to `contextMenuScrollOutsideHandler` to be more descriptive about what case it is handling.
* `contextMenuOutsideHandler2` renamed to `clickBlurOutsideHandler` since it is the handler for click and contextMenu triggers (similar to `clickOutsideHandler`)