### PR TITLE
fix popup of trigger in another trigger click will cause parent trigger close

### DIFF
--- a/src/Popup.js
+++ b/src/Popup.js
@@ -14,12 +14,13 @@ class Popup extends Component {
     getClassNameFromAlign: PropTypes.func,
     onAlign: PropTypes.func,
     getRootDomNode: PropTypes.func,
-    onMouseEnter: PropTypes.func,
     align: PropTypes.any,
     destroyPopupOnHide: PropTypes.bool,
     className: PropTypes.string,
     prefixCls: PropTypes.string,
+    onMouseEnter: PropTypes.func,
     onMouseLeave: PropTypes.func,
+    onMouseDown: PropTypes.func,
     stretch: PropTypes.string,
     children: PropTypes.node,
     point: PropTypes.shape({
@@ -138,7 +139,7 @@ class Popup extends Component {
       align, visible,
       prefixCls, style, getClassNameFromAlign,
       destroyPopupOnHide, stretch, children,
-      onMouseEnter, onMouseLeave,
+      onMouseEnter, onMouseLeave, onMouseDown,
     } = this.props;
     const className = this.getClassName(this.currentAlignClassName ||
       getClassNameFromAlign(align));
@@ -185,6 +186,7 @@ class Popup extends Component {
       ref: savePopupRef,
       onMouseEnter,
       onMouseLeave,
+      onMouseDown,
       style: newStyle,
     };
     if (destroyPopupOnHide) {

--- a/src/PopupInner.js
+++ b/src/PopupInner.js
@@ -9,6 +9,7 @@ class PopupInner extends Component {
     prefixCls: PropTypes.string,
     onMouseEnter: PropTypes.func,
     onMouseLeave: PropTypes.func,
+    onMouseDown: PropTypes.func,
     children: PropTypes.any,
   };
   render() {
@@ -22,6 +23,7 @@ class PopupInner extends Component {
         className={className}
         onMouseEnter={props.onMouseEnter}
         onMouseLeave={props.onMouseLeave}
+        onMouseDown={props.onMouseDown}
         style={props.style}
       >
         <LazyRenderBox className={`${props.prefixCls}-content`} visible={props.visible}>

--- a/tests/basic.spec.js
+++ b/tests/basic.spec.js
@@ -714,6 +714,83 @@ describe('rc-trigger', function main() {
       // height should be same, should not have break lines inside words
       expect(popupNodeHeightOfOneWord).to.equal(popupNodeHeightOfSeveralWords);
     });
+
+    // https://github.com/ant-design/ant-design/issues/9114
+    it('click in popup of popup', (done) => {
+      const builtinPlacements = {
+        right: {
+          points: ['cl', 'cr'],
+        },
+      };
+
+      let innerVisible = null;
+      function onInnerPopupVisibleChange(value) {
+        innerVisible = value;
+      }
+
+      const innerTrigger = (
+        <div style={{ background: 'rgba(255, 0, 0, 0.3)' }}>
+          <Trigger
+            onPopupVisibleChange={onInnerPopupVisibleChange}
+            popupPlacement="right"
+            action={['click']}
+            builtinPlacements={builtinPlacements}
+            popup={
+              <div id="issue_9114_popup" style={{ background: 'rgba(0, 255, 0, 0.3)' }}>
+                Final Popup
+              </div>
+            }
+          >
+            <div id="issue_9114_trigger">another trigger in popup</div>
+          </Trigger>
+        </div>
+      );
+
+      let visible = null;
+      function onPopupVisibleChange(value) {
+        visible = value;
+      }
+
+      const trigger = ReactDOM.render(
+        <Trigger
+          onPopupVisibleChange={onPopupVisibleChange}
+          popupPlacement="right"
+          action={['click']}
+          builtinPlacements={builtinPlacements}
+          popup={innerTrigger}
+        >
+          <span style={{ margin: 20 }}>basic trigger</span>
+        </Trigger>,
+        div
+      );
+
+      // Basic click
+      const domNode = ReactDOM.findDOMNode(trigger);
+      Simulate.click(domNode);
+
+      setTimeout(() => {
+        expect(visible).to.be(true);
+        expect(innerVisible).to.be(null);
+
+        const innerDomNode = document.getElementById('issue_9114_trigger');
+        Simulate.click(innerDomNode);
+
+        setTimeout(() => {
+          expect(visible).to.be(true);
+          expect(innerVisible).to.be(true);
+
+          const popupDomNode = document.getElementById('issue_9114_popup');
+          Simulate.click(popupDomNode);
+
+          setTimeout(() => {
+            expect(visible).to.be(true);
+            expect(innerVisible).to.be(true);
+
+            done();
+          });
+        }, 100);
+      }, 100);
+    });
   });
 
   describe('utils/saveRef', () => {


### PR DESCRIPTION
ref: https://github.com/ant-design/ant-design/issues/9114

英文不太好描述，用中文了。
就是如果一个 Trigger 的 Popup 里面放了另一个 Trigger，这个子 Trigger 的Popup 被点击会导致父 Trigger 被关闭。
因为我们的外部点击监听是通过 `addEventListener` 触发，因而没有走 React 的生命周期。

现在增加一个 context 传递方法，当子 Trigger 的 Popup 被点击的时候，父 Trigger 的 context 方法被调用会临时锁定一下，这时通过 document 的 mouseDown 事件关闭被阻止：
![kapture 2018-09-14 at 16 51 13](https://user-images.githubusercontent.com/5378891/45540210-6c582800-b83e-11e8-8435-01c4d2e3b31b.gif)



另: rc-trigger 里的逻辑比较多，感觉需要找个时间整理一下。