### PR TITLE
fix popup unexpected close on touch devices

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -329,7 +329,8 @@ export default class Trigger extends React.Component {
 
     const target = event.target;
     const root = findDOMNode(this);
-    if (!contains(root, target) && !this.hasPopupMouseDown) {
+    const popupNode = this.getPopupDomNode();
+    if (!contains(root, target) && !this.hasPopupMouseDown && !contains(popupNode, target)) {
       this.close();
     }
   }


### PR DESCRIPTION
## The Issule

After `rc-trigger` updates to 2.6.0, the `Popup` will close when it's touched in a touch device.

Try the official demo [http://react-component.github.io/trigger/examples/simple.html](http://react-component.github.io/trigger/examples/simple.html), as following steps:

- select trigger: `click`
- open Chrome Dev Tools, simulate `iPad`
- click the trigger, and `<Popup>` will appear.
- click the popup, which is `i am a popup`, the popup will be closed after the click. But it shouldn't be.

## The Problem

To determine whether to close the Popup, version 2.6.0 use the following expression([source code](https://github.com/react-component/trigger/blob/master/src/index.js#L332)):

```js
!contains(root, target) && !this.hasPopupMouseDown
```

While `this.hasPopupMouseDown` depends on `this.onPopupMouseDown`. 

But when using touch devices, when the Popup is touched, events fire order follows:

1. `onTouchStart` event of Popup(`this.onDocumentClick`)
2. `onMouseDown` event of Popup(`this.onPopupMouseDown`)
3. `onMouseDown` event of document(`this.onDocumentClick`)

In the first step, `this.hasPopupMouseDown` is `false`, so the Popup will be closed.

What's more, because of the use of `fastclick.js`， in iOS device, the `touchend` event will [prevent the actual click from going though](https://github.com/ftlabs/fastclick/blob/master/lib/fastclick.js#L602), so the following two events will never be fired, and `this.hasPopupMouseDown` will always be `false`.

## The Solution

Restore the if expression to former version(2.5.4) 

```js
!contains(root, target) && !this.hasPopupMouseDown && !contains(popupNode, target)
```

and it works fine.

ref: ant-design/ant-design#12388