### PR TITLE
:sparkles: access popup container

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -429,6 +429,7 @@ export default class Trigger extends React.Component {
     popupContainer.style.top = '0';
     popupContainer.style.left = '0';
     popupContainer.style.width = '100%';
+    this.popupContainer = popupContainer;
     const mountNode = props.getPopupContainer ?
       props.getPopupContainer(findDOMNode(this)) : props.getDocument().body;
     mountNode.appendChild(popupContainer);


### PR DESCRIPTION
I have the same requirement like this issue. https://github.com/react-component/trigger/issues/94

add an instance variable to access popup container.

- [x] lint pass.
- [x] test pass.