### PR TITLE
Feature: Close popup on "escape" keydown

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,12 @@ ReactDOM.render((
           <td>whether to support click mask to hide</td>
         </tr>
         <tr>
+          <td>keyboard</td>
+          <td>Boolean</td>
+          <td>false</td>
+          <td>whether support press esc to close</td>
+        </tr>
+        <tr>
           <td>popupVisible</td>
           <td>boolean</td>
           <td></td>

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -123,6 +123,12 @@ class Test extends React.Component {
     });
   }
 
+  onKeyboard = (e) => {
+    this.setState({
+      keyboard: e.target.checked,
+    });
+  }
+
   destroy = () => {
     this.setState({
       destroyed: true,
@@ -248,6 +254,16 @@ class Test extends React.Component {
           maskClosable
         </label>
 
+        &nbsp;&nbsp;&nbsp;&nbsp;
+        <label>
+          <input
+            checked={!!this.state.keyboard}
+            type="checkbox"
+            onChange={this.onKeyboard}
+          />
+          keyboard
+        </label>
+
         <br />
         <label>
           offsetX:
@@ -296,6 +312,7 @@ class Test extends React.Component {
             </div>
           }
           popupTransitionName={state.transitionName}
+          keyboard={state.keyboard}
         >
           <a
             style={{ margin: 20, display: 'inline-block', background: `rgba(255, 0, 0, 0.05)` }}

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import contains from 'rc-util/lib/Dom/contains';
 import addEventListener from 'rc-util/lib/Dom/addEventListener';
 import ContainerRender from 'rc-util/lib/ContainerRender';
 import Portal from 'rc-util/lib/Portal';
+import KeyCode from 'rc-util/lib/KeyCode';
 import classNames from 'classnames';
 
 import { getAlignFromPlacement, getAlignPopupClassName } from './utils';
@@ -78,6 +79,7 @@ export default class Trigger extends React.Component {
     maskAnimation: PropTypes.string,
     stretch: PropTypes.string,
     alignPoint: PropTypes.bool, // Maybe we can support user pass position in the future
+    keyboard: PropTypes.bool,
   };
 
   static contextTypes = contextTypes;
@@ -105,6 +107,7 @@ export default class Trigger extends React.Component {
     action: [],
     showAction: [],
     hideAction: [],
+    keyboard: false,
   };
 
   constructor(props) {
@@ -196,6 +199,13 @@ export default class Trigger extends React.Component {
         this.contextMenuOutsideHandler2 = addEventListener(window,
           'blur', this.onContextMenuClose);
       }
+      // close popup on escape keyboard event
+      if (!this.keyDownHandler && props.keyboard) {
+        currentDocument = currentDocument || props.getDocument();
+        this.keyDownHandler = addEventListener(currentDocument,
+          'keydown', this.onKeyDown);
+      }
+
       return;
     }
 
@@ -330,6 +340,14 @@ export default class Trigger extends React.Component {
     const target = event.target;
     const root = findDOMNode(this);
     if (!contains(root, target) && !this.hasPopupMouseDown) {
+      this.close();
+    }
+  }
+
+  onKeyDown = (event) => {
+    // close popup if escape key pressed
+    if (event.keyCode === KeyCode.ESC || event.key === 'Escape') {
+      event.stopPropagation();
       this.close();
     }
   }
@@ -515,6 +533,11 @@ export default class Trigger extends React.Component {
     if (this.touchOutsideHandler) {
       this.touchOutsideHandler.remove();
       this.touchOutsideHandler = null;
+    }
+
+    if (this.keyDownHandler) {
+      this.keyDownHandler.remove();
+      this.keyDownHandler = null;
     }
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -28,3 +28,33 @@ export function getAlignPopupClassName(builtinPlacements, prefixCls, align, isAl
 export function saveRef(name, component) {
   this[name] = component;
 }
+
+// TestUtils.Simulate.keyDown doesn't work on PhantomJS
+// https://github.com/ariya/phantomjs/issues/11289#issuecomment-278147426
+export function keyboardEvent(eventType, init) {
+  try {
+    return new KeyboardEvent(eventType, init);
+  } catch (error) {
+    const modKeys = [
+      init.ctrlKey ? 'Control' : '',
+      init.shiftKey ? 'Shift' : '',
+      init.altKey ? 'Alt' : '',
+      init.altGrKey ? 'AltGr' : '',
+      init.metaKey ? 'Meta' : '',
+    ].join(' ');
+    const keyEvent = document.createEvent('KeyboardEvent');
+    keyEvent.initKeyboardEvent(
+      eventType, // type
+      false, // canBubble
+      false, // cancelable
+      window, // view
+      init.char || '', // char
+      init.keyCode || 0, // key
+      0, // location
+      modKeys,
+      init.repeat || false,
+    );
+    keyEvent.key = init.key;
+    return keyEvent;
+  }
+}

--- a/tests/basic.spec.js
+++ b/tests/basic.spec.js
@@ -11,7 +11,7 @@ import '../assets/index.less';
 import Trigger from '../index';
 import './basic.less';
 import async from 'async';
-import { saveRef } from '../src/utils';
+import { saveRef, keyboardEvent } from '../src/utils';
 
 const Simulate = TestUtils.Simulate;
 const scryRenderedDOMComponentsWithClass = TestUtils.scryRenderedDOMComponentsWithClass;
@@ -893,6 +893,66 @@ describe('rc-trigger', function main() {
       ), div);
       const domNode = ReactDOM.findDOMNode(trigger);
       expect(domNode.className).to.be('target className-in-trigger-1 className-in-trigger-2');
+    });
+  });
+
+  describe('keyboard', () => {
+    let visible;
+    const onChange = (value) => {
+      visible = value;
+    };
+
+    it('esc key works if keyboard=true ', () => {
+      const trigger = ReactDOM.render(
+        <Trigger
+          keyboard
+          popup={<div />}
+          action={['click']}
+          popupAlign={placementAlignMap.right}
+          onPopupVisibleChange={onChange}
+        >
+          <div>click</div>
+        </Trigger>,
+        div
+      );
+      const domNode = ReactDOM.findDOMNode(trigger);
+
+      // click trigger and show popup
+      Simulate.click(domNode);
+      expect(visible).to.be(true);
+
+      // click escape
+      const event = keyboardEvent('keydown', { key: 'Escape', keyCode: 27 });
+      document.dispatchEvent(event);
+
+      // assert that popup hidden
+      expect(visible).to.be(false);
+    });
+
+    it('esc key doesn\'t work if keyboard=false ', () => {
+      const trigger = ReactDOM.render(
+        <Trigger
+          popup={<div />}
+          action={['click']}
+          popupAlign={placementAlignMap.right}
+          onPopupVisibleChange={onChange}
+        >
+          <div>click</div>
+        </Trigger>,
+        div
+      );
+      const domNode = ReactDOM.findDOMNode(trigger);
+
+      // click trigger and show popup
+      Simulate.click(domNode);
+      expect(visible).to.be(true);
+
+      // click escape
+      const event = keyboardEvent('keydown', { key: 'Escape', keyCode: 27 });
+      document.dispatchEvent(event);
+
+      // assert that popup still visible
+      expect(visible).to.be(true);
     });
   });
 });


### PR DESCRIPTION
Due to issue https://github.com/ant-design/ant-design/issues/14699 in which popover stays open when modal is escaped, I'd like to allow first closing the popover, then the modal (similar to select in modal behavior).

### Commit #&#8203;1: Added feature
Added a prop `keyboard` (not the best keyword but following [the similar feature](https://github.com/react-component/dialog/blob/088d99a20fff8c4a29af66b754c1fe7b1a34f55d/src/IDialogPropTypes.tsx#L5) in `<Dialog>`. Let me know if you'd prefer a different name), false by default.
Adds keydown listener when popup visible, self removes when closed.

```jsx
<Trigger keyboard ... />
```

### Commit #&#8203; 2: Updated simple example
Added checkbox "keyboard" to `simple.html` and when checked, no matter what action trigger opens the popup, press "esc" and it closes.

<img width="300" src="https://user-images.githubusercontent.com/486954/52167103-ce96c400-271e-11e9-9cd9-bd62681dc8fb.gif" />

### Commit #&#8203;3: Updated Readme.md
Updated the table of props.
<img width="415" alt="screen shot 2019-02-02 at 19 20 21" src="https://user-images.githubusercontent.com/486954/52167192-f6d2f280-271f-11e9-870e-c28d77865ede.png">

### Commit #&#8203;4: Added tests
Test #&#8203;;1 - `keyboard=true`, open popup, click esc - assert that popup closed.
Test #&#8203;2 - `keyboard=false`, open popup, click esc - assert that popup is still open.

Notice that simulating an "esc" event can't be done with `TestUtils.Simulate.keyDown` probably cause PhantomJS doesn't support the current browser API. So I made a simple polyfill util. Works well.