### PR TITLE
Make the native event execute after the react event

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -323,15 +323,17 @@ export default class Trigger extends React.Component {
   };
 
   onDocumentClick = (event) => {
-    if (this.props.mask && !this.props.maskClosable) {
-      return;
-    }
-
-    const target = event.target;
-    const root = findDOMNode(this);
-    if (!contains(root, target) && !this.hasPopupMouseDown) {
-      this.close();
-    }
+    setTimeout(function() {
+      if (this.props.mask && !this.props.maskClosable) {
+        return;
+      }
+  
+      const target = event.target;
+      const root = findDOMNode(this);
+      if (!contains(root, target) && !this.hasPopupMouseDown) {
+        this.close();
+      }
+    }, 70);
   }
 
   getPopupDomNode() {

--- a/src/index.js
+++ b/src/index.js
@@ -323,11 +323,11 @@ export default class Trigger extends React.Component {
   };
 
   onDocumentClick = (event) => {
-    setTimeout(function() {
+    setTimeout(() => {
       if (this.props.mask && !this.props.maskClosable) {
         return;
       }
-  
+
       const target = event.target;
       const root = findDOMNode(this);
       if (!contains(root, target) && !this.hasPopupMouseDown) {


### PR DESCRIPTION
Fix https://github.com/ant-design/ant-design/issues/15179
这不是移动端才有  pc端也有
https://github.com/react-component/trigger/blob/master/src/index.js#L179
trigger 直接监听的document  但是原生事件是比react的合成事件先执行的 先触发的关闭  
https://fortes.com/2018/react-and-dom-events/
加个70ms延迟 hack一下 
@afc163  @zombieJ  