### PR TITLE
Fix(Dropdown): init incorrectly if visible is true

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -585,6 +585,7 @@ export default class Trigger extends React.Component {
 
   savePopup = (node) => {
     this._component = node;
+    this.props.afterPopupVisibleChange(this.props.visible)
   }
 
   render() {


### PR DESCRIPTION
### This is a ...

- [x] Bug fix

### What's the background?

close  https://github.com/ant-design/ant-design/issues/13128

### Solution

Invoke `afterVisibleChange` of Dropdown after `popupInstance` is bound to `trigger` to set overlay's min-width. So that overlay's initialization can be invoked without visible changing.

### Self Check before Merge

- [x] Doc is ready or not need
- [x] Demo is provided or not need
- [x] TypeScript definition is ready or not need
- [x] Changelog provided

