### PR TITLE
feat: add autoDestroy prop(#19536);

### DIFF
--- a/examples/simple.js
+++ b/examples/simple.js
@@ -158,6 +158,12 @@ class Test extends React.Component {
     });
   };
 
+  autoDestroy = e => {
+    this.setState({
+      autoDestroy: e.target.checked,
+    });
+  };
+
   render() {
     const { state } = this;
     const { trigger } = state;
@@ -250,6 +256,15 @@ class Test extends React.Component {
           &nbsp;&nbsp;&nbsp;&nbsp;
           <label>
             <input
+              checked={!!this.state.autoDestroy}
+              type="checkbox"
+              onChange={this.autoDestroy}
+            />
+            autoDestroy
+          </label>
+          &nbsp;&nbsp;&nbsp;&nbsp;
+          <label>
+            <input
               checked={!!this.state.mask}
               type="checkbox"
               onChange={this.onMask}
@@ -294,6 +309,7 @@ class Test extends React.Component {
             popupAlign={this.getPopupAlign()}
             popupPlacement={state.placement}
             destroyPopupOnHide={this.state.destroyPopupOnHide}
+            autoDestroy={this.state.autoDestroy}
             // zIndex={40}
             mask={this.state.mask}
             maskClosable={this.state.maskClosable}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -75,6 +75,7 @@ export interface TriggerProps {
   popupAlign?: AlignType;
   popupVisible?: boolean;
   defaultPopupVisible?: boolean;
+  autoDestroy: boolean;
 
   stretch?: string;
   alignPoint?: boolean; // Maybe we can support user pass position in the future
@@ -136,6 +137,7 @@ export function generateTrigger(
       action: [],
       showAction: [],
       hideAction: [],
+      autoDestroy: false,
     };
 
     popupRef = React.createRef<Popup>();
@@ -730,7 +732,13 @@ export function generateTrigger(
 
     render() {
       const { popupVisible } = this.state;
-      const { children, forceRender, alignPoint, className } = this.props;
+      const {
+        children,
+        forceRender,
+        alignPoint,
+        className,
+        autoDestroy,
+      } = this.props;
       const child = React.Children.only(children) as React.ReactElement;
       const newChildProps: HTMLAttributes<HTMLElement> & { key: string } = {
         key: 'trigger',
@@ -800,6 +808,10 @@ export function generateTrigger(
             {this.getComponent()}
           </PortalComponent>
         );
+      }
+
+      if (!popupVisible && autoDestroy) {
+        portal = null;
       }
 
       return (

--- a/tests/basic.test.jsx
+++ b/tests/basic.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import Portal from 'rc-util/lib/Portal';
 import Trigger from '../src';
 
 const autoAdjustOverflow = {
@@ -379,6 +380,43 @@ describe('Trigger.Basic', () => {
       expect(wrapper.instance().getPopupDomNode()).toBeTruthy();
       wrapper.trigger();
       expect(wrapper.instance().getPopupDomNode()).toBeFalsy();
+    });
+  });
+
+  describe('support autoDestroy', () => {
+    it('defaults to false', () => {
+      const wrapper = mount(
+        <Trigger
+          action={['click']}
+          popupAlign={placementAlignMap.topRight}
+          popup={<strong>trigger</strong>}
+        >
+          <div className="target">click</div>
+        </Trigger>,
+      );
+      expect(wrapper.prop('autoDestroy')).toBeFalsy();
+      wrapper.trigger();
+      expect(wrapper.find(Portal).exists()).toBe(true);
+      wrapper.trigger();
+      expect(wrapper.find(Portal).exists()).toBe(true);
+    });
+
+    it('set true will destroy portal on hide', () => {
+      const wrapper = mount(
+        <Trigger
+          action={['click']}
+          autoDestroy
+          popupAlign={placementAlignMap.topRight}
+          popup={<strong>trigger</strong>}
+        >
+          <div className="target">click</div>
+        </Trigger>,
+      );
+
+      wrapper.trigger();
+      expect(wrapper.find(Portal).exists()).toBe(true);
+      wrapper.trigger();
+      expect(wrapper.find(Portal).exists()).toBe(false);
     });
   });
 


### PR DESCRIPTION
添加了`autoDestroy`属性，默认为`false`，和`destroyPopupOnHide`不同的是关闭后直接销毁Portal和子内容，`destroyPopupOnHide`只会删除Portal的子元素。
[#19536](https://github.com/ant-design/ant-design/issues/19536)