### PR TITLE
fix: Motion state record

### DIFF
--- a/src/Popup.tsx
+++ b/src/Popup.tsx
@@ -78,6 +78,9 @@ interface PopupState {
   status: PopupStatus;
   prevVisible: boolean;
   alignClassName: string;
+
+  /** Record for CSSMotion is working or not */
+  inMotion: boolean;
 }
 
 interface AlignRefType {
@@ -96,6 +99,8 @@ class Popup extends Component<PopupProps, PopupState> {
     status: null,
     prevVisible: null, // eslint-disable-line react/no-unused-state
     alignClassName: null,
+
+    inMotion: false,
   };
 
   public popupRef = React.createRef<HTMLDivElement>();
@@ -108,7 +113,7 @@ class Popup extends Component<PopupProps, PopupState> {
 
   static getDerivedStateFromProps(
     { visible, ...props }: PopupProps,
-    { prevVisible, status }: PopupState,
+    { prevVisible, status, inMotion }: PopupState,
   ) {
     const newState: Partial<PopupState> = { prevVisible: visible, status };
 
@@ -117,12 +122,11 @@ class Popup extends Component<PopupProps, PopupState> {
     if (prevVisible === null && visible === false) {
       // Init render should always be stable
       newState.status = 'stable';
+      newState.inMotion = false;
     } else if (visible !== prevVisible) {
-      if (
-        visible ||
-        (supportMotion(mergedMotion) &&
-          ['motion', 'AfterMotion', 'stable'].includes(status))
-      ) {
+      newState.inMotion = false;
+
+      if (visible || (supportMotion(mergedMotion) && inMotion)) {
         newState.status = null;
       } else {
         newState.status = 'stable';
@@ -321,6 +325,14 @@ class Popup extends Component<PopupProps, PopupState> {
     if (status === 'afterAlign' || status === 'beforeMotion') {
       mergedMotionVisible = false;
     }
+
+    // Update trigger to tell if is in motion
+    ['onEnterStart', 'onAppearStart', 'onLeaveStart'].forEach(event => {
+      mergedMotion[event] = (...args) => {
+        mergedMotion?.[event]?.(...args);
+        this.setState({ inMotion: true });
+      };
+    });
 
     // ================== Align ==================
     const mergedAlignDisabled =

--- a/tests/popup.test.jsx
+++ b/tests/popup.test.jsx
@@ -20,14 +20,18 @@ describe('Popup', () => {
       const props = { visible: false };
       const state = { prevVisible: null, status: 'something' };
 
-      expect(Popup.getDerivedStateFromProps(props, state).status).toBe('stable');
+      expect(Popup.getDerivedStateFromProps(props, state).status).toBe(
+        'stable',
+      );
     });
 
     it('does not change when visible is unchanged', () => {
       const props = { visible: true };
       const state = { prevVisible: true, status: 'something' };
 
-      expect(Popup.getDerivedStateFromProps(props, state).status).toBe('something');
+      expect(Popup.getDerivedStateFromProps(props, state).status).toBe(
+        'something',
+      );
     });
 
     it('returns null when visible is changed to true', () => {
@@ -41,7 +45,9 @@ describe('Popup', () => {
       const props = { visible: false };
       const state = { prevVisible: true, status: 'something' };
 
-      expect(Popup.getDerivedStateFromProps(props, state).status).toBe('stable');
+      expect(Popup.getDerivedStateFromProps(props, state).status).toBe(
+        'stable',
+      );
     });
 
     it('returns null when visible is changed to false and motion is started', () => {
@@ -51,7 +57,7 @@ describe('Popup', () => {
           motionName: 'enter',
         },
       };
-      const state = { prevVisible: true, status: 'motion' };
+      const state = { prevVisible: true, status: 'motion', inMotion: true };
 
       expect(Popup.getDerivedStateFromProps(props, state).status).toBe(null);
     });
@@ -65,7 +71,9 @@ describe('Popup', () => {
       };
       const state = { prevVisible: true, status: 'beforeMotion' };
 
-      expect(Popup.getDerivedStateFromProps(props, state).status).toBe('stable');
+      expect(Popup.getDerivedStateFromProps(props, state).status).toBe(
+        'stable',
+      );
     });
   });
 


### PR DESCRIPTION
横向快速移动鼠标，tooltip 会不消失：
https://codesandbox.io/s/beautiful-faraday-zfmgw?file=/index.js

原因在于 setState 是异步操作被 batch update，导致 motion 没有启动就被结束，而 Trigger 层以为已经触发了 motion 就继续执行锁逻辑导致 PopupInner 弹出后没人管的状态。

这个 fix 添加了一个额外的事件监听用于检查是否真的在进行动画。可能会有新 bug，随遇随修。