### PR TITLE
fix: component can still be selected when disabled

### DIFF
--- a/examples/case.tsx
+++ b/examples/case.tsx
@@ -1,9 +1,9 @@
 /* eslint no-console:0 */
 
 import React from 'react';
+import { CSSMotionProps } from 'rc-motion';
 import Trigger, { BuildInPlacements } from '../src';
 import './case.less';
-import { MotionType } from '../src/interface';
 
 const builtinPlacements: BuildInPlacements = {
   left: {
@@ -32,11 +32,11 @@ const builtinPlacements: BuildInPlacements = {
   },
 };
 
-const Motion: MotionType = {
+const Motion: CSSMotionProps = {
   motionName: 'case-motion',
 };
 
-const MaskMotion: MotionType = {
+const MaskMotion: CSSMotionProps = {
   motionName: 'mask-motion',
 };
 
@@ -98,7 +98,10 @@ const Demo = () => {
   const [placement, placementProps] = useControl('value', 'right');
   const [stretch, stretchProps] = useControl('value', '');
   const [motion, motionProps] = useControl('checked', true);
-  const [destroyPopupOnHide, destroyPopupOnHideProps] = useControl('checked', false);
+  const [destroyPopupOnHide, destroyPopupOnHideProps] = useControl(
+    'checked',
+    false,
+  );
   const [mask, maskProps] = useControl('checked', false);
   const [maskClosable, maskClosableProps] = useControl('checked', true);
   const [forceRender, forceRenderProps] = useControl('checked', false);
@@ -215,7 +218,11 @@ const Demo = () => {
             }}
           >
             <div
-              style={{ margin: 20, display: 'inline-block', background: 'rgba(255, 0, 0, 0.05)' }}
+              style={{
+                margin: 20,
+                display: 'inline-block',
+                background: 'rgba(255, 0, 0, 0.05)',
+              }}
               tabIndex={0}
               role="button"
             >

--- a/src/Popup.tsx
+++ b/src/Popup.tsx
@@ -303,7 +303,7 @@ class Popup extends Component<PopupProps, PopupState> {
       ...sizeStyle,
       ...this.getZIndexStyle(),
       ...style,
-      opacity: status === 'stable' || !visible ? undefined : 0,
+      visibility: status === 'stable' || !visible ? 'visible' : 'hidden',
     };
 
     // ================= Motions =================

--- a/src/Popup.tsx
+++ b/src/Popup.tsx
@@ -303,7 +303,8 @@ class Popup extends Component<PopupProps, PopupState> {
       ...sizeStyle,
       ...this.getZIndexStyle(),
       ...style,
-      visibility: status === 'stable' || !visible ? 'visible' : 'hidden',
+      opacity: status === 'stable' || !visible ? undefined : 0,
+      pointerEvents: status === 'stable' || !visible ? undefined : 'none',
     };
 
     // ================= Motions =================

--- a/tests/util.test.jsx
+++ b/tests/util.test.jsx
@@ -84,7 +84,7 @@ describe('Trigger.Util', () => {
       );
 
       expect(wrapper.html()).toEqual(
-        '<div>light</div><div><div class="rc-trigger-popup" style="visibility: hidden;"><div>bamboo</div></div></div>',
+        '<div>light</div><div><div class="rc-trigger-popup" style="opacity: 0; pointer-events: none;"><div>bamboo</div></div></div>',
       );
     });
   });

--- a/tests/util.test.jsx
+++ b/tests/util.test.jsx
@@ -84,7 +84,7 @@ describe('Trigger.Util', () => {
       );
 
       expect(wrapper.html()).toEqual(
-        '<div>light</div><div><div class="rc-trigger-popup" style="opacity: 0;"><div>bamboo</div></div></div>',
+        '<div>light</div><div><div class="rc-trigger-popup" style="visibility: hidden;"><div>bamboo</div></div></div>',
       );
     });
   });


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design/issues/26241

Popup的status为null时，弹出的picker组件opacity为0，但鼠标依然可以选择上面的日期，导致了issue那个问题

![image](https://user-images.githubusercontent.com/17452527/90630785-3efb2c80-e254-11ea-8df0-a6056232cc7e.png)
![image](https://user-images.githubusercontent.com/17452527/90630788-41f61d00-e254-11ea-9550-83caf3e8b793.png)
