### PR TITLE
fix: Patch for getPopupContainer check

### DIFF
--- a/examples/case.tsx
+++ b/examples/case.tsx
@@ -196,6 +196,11 @@ const Demo = () => {
                 adjustY: 1,
               },
             }}
+            popupVisible
+            getPopupContainer={node => {
+              console.log('G<>>>>>>', node);
+              return node.parentElement;
+            }}
             popupPlacement={placement}
             destroyPopupOnHide={destroyPopupOnHide}
             mask={mask}

--- a/examples/case.tsx
+++ b/examples/case.tsx
@@ -196,11 +196,6 @@ const Demo = () => {
                 adjustY: 1,
               },
             }}
-            popupVisible
-            getPopupContainer={node => {
-              console.log('G<>>>>>>', node);
-              return node.parentElement;
-            }}
             popupPlacement={placement}
             destroyPopupOnHide={destroyPopupOnHide}
             mask={mask}

--- a/package.json
+++ b/package.json
@@ -61,6 +61,6 @@
     "classnames": "^2.2.6",
     "rc-align": "^4.0.0",
     "rc-motion": "^2.0.0",
-    "rc-util": "^5.2.1"
+    "rc-util": "^5.3.4"
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -540,10 +540,17 @@ export function generateTrigger(
     };
 
     attachParent = (popupContainer: HTMLDivElement) => {
-      const { props } = this;
-      const mountNode = props.getPopupContainer
-        ? props.getPopupContainer(this.getRootDomNode())
-        : props.getDocument().body;
+      const { getPopupContainer, getDocument } = this.props;
+      const domNode = this.getRootDomNode();
+
+      let mountNode: HTMLElement;
+      if (!getPopupContainer) {
+        mountNode = getDocument().body;
+      } else if (domNode) {
+        // Compatible for sync render usage
+        // https://codesandbox.io/s/eloquent-mclean-ss93m?file=/src/App.js
+        mountNode = getPopupContainer(domNode);
+      }
 
       if (mountNode) {
         mountNode.appendChild(popupContainer);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -146,6 +146,8 @@ export function generateTrigger(
 
     triggerRef = React.createRef<React.ReactInstance>();
 
+    attachId?: number;
+
     clickOutsideHandler: CommonEventHandler;
 
     touchOutsideHandler: CommonEventHandler;
@@ -540,14 +542,17 @@ export function generateTrigger(
     };
 
     attachParent = (popupContainer: HTMLDivElement) => {
+      raf.cancel(this.attachId);
+
       const { getPopupContainer, getDocument } = this.props;
       const domNode = this.getRootDomNode();
 
       let mountNode: HTMLElement;
       if (!getPopupContainer) {
         mountNode = getDocument().body;
-      } else if (domNode) {
-        // Compatible for sync render usage
+      } else if (domNode || getPopupContainer.length === 0) {
+        // Compatible for legacy getPopupContainer with domNode argument.
+        // If no need `domNode` argument, will call directly.
         // https://codesandbox.io/s/eloquent-mclean-ss93m?file=/src/App.js
         mountNode = getPopupContainer(domNode);
       }
@@ -556,7 +561,7 @@ export function generateTrigger(
         mountNode.appendChild(popupContainer);
       } else {
         // Retry after frame render in case parent not ready
-        raf(() => {
+        this.attachId = raf(() => {
           this.attachParent(popupContainer);
         });
       }

--- a/tests/basic.test.jsx
+++ b/tests/basic.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import { act } from 'react-dom/test-utils';
 import { spyElementPrototypes } from 'rc-util/lib/test/domHook';
 import Portal from 'rc-util/lib/Portal';
 import Trigger from '../src';
@@ -682,5 +683,61 @@ describe('Trigger.Basic', () => {
     expect(popupDomNode.style.zIndex).toBe(style.zIndex.toString());
     expect(popupDomNode.style.color).toBe(style.color);
     expect(popupDomNode.style.top).toBe(`${style.top}px`);
+  });
+
+  describe('getContainer', () => {
+    it('not trigger when dom not ready', () => {
+      const getPopupContainer = jest.fn(node => node.parentElement);
+
+      function Demo() {
+        return (
+          <Trigger
+            popupVisible
+            getPopupContainer={getPopupContainer}
+            popup={<strong className="x-content">tooltip2</strong>}
+          >
+            <div className="target">click</div>
+          </Trigger>
+        );
+      }
+
+      const wrapper = mount(<Demo />);
+
+      expect(getPopupContainer).toHaveReturnedTimes(0);
+
+      act(() => {
+        jest.runAllTimers();
+      });
+      expect(getPopupContainer).toHaveReturnedTimes(1);
+      expect(getPopupContainer).toHaveBeenCalledWith(
+        wrapper.find('.target').instance(),
+      );
+    });
+
+    it('not trigger when dom no need', () => {
+      let triggerTimes = 0;
+      const getPopupContainer = () => {
+        triggerTimes += 1;
+        return document.body;
+      };
+
+      function Demo() {
+        return (
+          <Trigger
+            popupVisible
+            getPopupContainer={getPopupContainer}
+            popup={<strong className="x-content">tooltip2</strong>}
+          >
+            <div className="target">click</div>
+          </Trigger>
+        );
+      }
+
+      const wrapper = mount(<Demo />);
+
+      expect(triggerTimes).toEqual(1);
+
+      wrapper.unmount();
+    });
   });
 });


### PR DESCRIPTION
`getPopupContainer` 的参数传入 `domNode` 产生了先有鸡还是先有蛋的问题。如果在渲染之后才触发 `getPopupContainer`，那么 `useEffect` 中就无法获取弹层内的节点：
```tsx
const someRef = useRef();
useEffect(() => {
  console.log(someRef.current);
}, []);

return (
  <Trigger
    visible
    getPopupContainer={(node) => node.parentNode}
    popup={<div ref={someRef} />}
  >
    <button />
  </Trigger>
);
```

如果先行渲染 `popup`，那么此时 `getPopupContainer` 的 dom 则还没有 ready。

现在做了如下改造，如果发现 `getPopupContainer` 没有 `triggerNode` 参数，则同时触发。如果有则异步触发。因而缩小冲突范围，只有在即用了 `triggerNode` 又使用 `popup[ref]` 的场景下会变成延迟触发。

ref https://codesandbox.io/s/eloquent-mclean-ss93m?file=/src/App.js