### PR TITLE
Adding null check before clearing mouseDownTimeout

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -250,7 +250,7 @@ export function generateTrigger(
     componentWillUnmount() {
       this.clearDelayTimer();
       this.clearOutsideHandler();
-      clearTimeout(this.mouseDownTimeout);
+      if (this.mouseDownTimeout) clearTimeout(this.mouseDownTimeout);
     }
 
     onMouseEnter = e => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -250,7 +250,7 @@ export function generateTrigger(
     componentWillUnmount() {
       this.clearDelayTimer();
       this.clearOutsideHandler();
-      if (this.mouseDownTimeout) clearTimeout(this.mouseDownTimeout);
+      if (this.mouseDownTimeout != null) clearTimeout(this.mouseDownTimeout);
     }
 
     onMouseEnter = e => {


### PR DESCRIPTION
Hello,

I was recently doing some performance testing on a virtual table component I had written. With rows constantly unmounting & remounting, I wanted to make sure the scroll was still smooth with tooltips (rc-tooltips to be exact).

During my tests, I noticed that a significant amount of my table cells needed to clear a timeout upon unmounting of the row, this caused lag in my scrolling.
 
![Screen Shot 2020-09-25 at 3 59 39 PM](https://user-images.githubusercontent.com/6536941/94310837-4646e180-ff48-11ea-92cb-97b558382116.png)

I found the call was made by rc-trigger in it's `componentWillUnmount` function. I added a simple null-check before the `clearTimeout` function and it significantly improved my scrolling performance.

I also noticed that the other timer, `this.delayTimer`, has its own function that handles this case -> `this.clearDelayTimer()` and was wondering why `this.mouseDownTimeout` did not have something similar.

Thanks!
Nick
