### PR TITLE
Add react and react-dom as peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,5 +62,9 @@
     "rc-align": "^4.0.0",
     "rc-motion": "^2.0.0",
     "rc-util": "^5.3.4"
+  },
+  "peerDependencies": {
+    "react": ">=16.9.0",
+    "react-dom": ">=16.9.0"
   }
 }


### PR DESCRIPTION
Fixes errors using Yarn 2 (berry).

See https://github.com/ant-design/ant-design/issues/27339 for details.
