### PR TITLE
fix: close motion not finished

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,7 @@ module.exports = {
   rules: {
     'default-case': 0,
     'import/no-extraneous-dependencies': 0,
+    'react-hooks/exhaustive-deps': 0,
     'react/no-find-dom-node': 0,
     'react/no-did-update-set-state': 0,
     'react/no-unused-state': 1,

--- a/src/Popup/useVisibleStatus.ts
+++ b/src/Popup/useVisibleStatus.ts
@@ -21,8 +21,17 @@ export default (
   visible: boolean,
   doMeasure: Func,
 ): [PopupStatus, (callback?: () => void) => void] => {
-  const [status, setStatus] = useState<PopupStatus>(null);
+  const [status, setInternalStatus] = useState<PopupStatus>(null);
   const rafRef = useRef<number>();
+  const destroyRef = useRef(false);
+
+  function setStatus(
+    nextStatus: PopupStatus | ((prevStatus: PopupStatus) => PopupStatus),
+  ) {
+    if (!destroyRef.current) {
+      setInternalStatus(nextStatus);
+    }
+  }
 
   function cancelRaf() {
     raf.cancel(rafRef.current);
@@ -63,7 +72,6 @@ export default (
     }
 
     if (status) {
-      cancelRaf();
       rafRef.current = raf(async () => {
         const index = StatusQueue.indexOf(status);
         const nextStatus = StatusQueue[index + 1];
@@ -76,6 +84,7 @@ export default (
 
   useEffect(
     () => () => {
+      destroyRef.current = true;
       cancelRaf();
     },
     [],


### PR DESCRIPTION
ref #240

`align` 状态更新是由 ResizeObserver 在 React 生命周期外控制，导致 effect 里清理会有时机问题。使用 ref 检查代替。