### PR TITLE
fix: right click popup should be closed on mousedown target element

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -405,7 +405,9 @@ export function generateTrigger(
       const root = this.getRootDomNode();
       const popupNode = this.getPopupDomNode();
       if (
-        !contains(root, target) &&
+        // mousedown on the target should also close popup when action is contextMenu.
+        // https://github.com/ant-design/ant-design/issues/29853
+        (!contains(root, target) || this.isContextMenuOnly()) &&
         !contains(popupNode, target) &&
         !this.hasPopupMouseDown
       ) {
@@ -697,6 +699,14 @@ export function generateTrigger(
       const { action, showAction } = this.props;
       return (
         action.indexOf('click') !== -1 || showAction.indexOf('click') !== -1
+      );
+    }
+
+    isContextMenuOnly() {
+      const { action } = this.props;
+      return (
+        action === 'contextMenu' ||
+        (action.length === 1 && action[0] === 'contextMenu')
       );
     }
 

--- a/tests/basic.test.jsx
+++ b/tests/basic.test.jsx
@@ -193,15 +193,6 @@ describe('Trigger.Basic', () => {
     });
 
     it('contextMenu works', () => {
-      // work around the global event listener issue with enzyme
-      // https://github.com/enzymejs/enzyme/issues/426
-      const eventMap = {
-        mousedown: null,
-      };
-      document.addEventListener = jest.fn((event, cb) => {
-        eventMap[event] = cb;
-      });
-
       const wrapper = mount(
         <Trigger
           action={['contextMenu']}
@@ -215,10 +206,14 @@ describe('Trigger.Basic', () => {
       wrapper.trigger('contextMenu');
       expect(wrapper.isHidden()).toBeFalsy();
 
-      // click target to close popup
-      eventMap.mousedown({ target: wrapper.find('.target').getDOMNode() });
-      jest.runAllTimers();
-      wrapper.update();
+      act(() => {
+        const mouseEvent = new MouseEvent('mousedown', {
+          target: wrapper.find('.target').getDOMNode(),
+        });
+        document.dispatchEvent(mouseEvent);
+        jest.runAllTimers();
+        wrapper.update();
+      });
 
       expect(wrapper.isHidden()).toBeTruthy();
     });

--- a/tests/basic.test.jsx
+++ b/tests/basic.test.jsx
@@ -207,10 +207,9 @@ describe('Trigger.Basic', () => {
       expect(wrapper.isHidden()).toBeFalsy();
 
       act(() => {
-        const mouseEvent = new MouseEvent('mousedown', {
-          target: wrapper.find('.target').getDOMNode(),
-        });
-        document.dispatchEvent(mouseEvent);
+        wrapper
+          .instance()
+          .onDocumentClick({ target: wrapper.find('.target').getDOMNode() });
         jest.runAllTimers();
         wrapper.update();
       });

--- a/tests/basic.test.jsx
+++ b/tests/basic.test.jsx
@@ -147,12 +147,7 @@ describe('Trigger.Basic', () => {
       );
 
       wrapper.trigger();
-      expect(
-        wrapper
-          .find('Popup')
-          .find('.x-content')
-          .text(),
-      ).toBe('tooltip2');
+      expect(wrapper.find('Popup').find('.x-content').text()).toBe('tooltip2');
 
       wrapper.trigger();
       expect(wrapper.isHidden()).toBeTruthy();
@@ -173,12 +168,7 @@ describe('Trigger.Basic', () => {
       );
 
       wrapper.trigger();
-      expect(
-        wrapper
-          .find('Popup')
-          .find('.x-content')
-          .text(),
-      ).toBe('tooltip3');
+      expect(wrapper.find('Popup').find('.x-content').text()).toBe('tooltip3');
 
       wrapper.trigger();
       expect(wrapper.isHidden()).toBeTruthy();
@@ -203,6 +193,15 @@ describe('Trigger.Basic', () => {
     });
 
     it('contextMenu works', () => {
+      // work around the global event listener issue with enzyme
+      // https://github.com/enzymejs/enzyme/issues/426
+      const eventMap = {
+        mousedown: null,
+      };
+      document.addEventListener = jest.fn((event, cb) => {
+        eventMap[event] = cb;
+      });
+
       const wrapper = mount(
         <Trigger
           action={['contextMenu']}
@@ -215,6 +214,13 @@ describe('Trigger.Basic', () => {
 
       wrapper.trigger('contextMenu');
       expect(wrapper.isHidden()).toBeFalsy();
+
+      // click target to close popup
+      eventMap.mousedown({ target: wrapper.find('.target').getDOMNode() });
+      jest.runAllTimers();
+      wrapper.update();
+
+      expect(wrapper.isHidden()).toBeTruthy();
     });
 
     describe('afterPopupVisibleChange can be triggered', () => {
@@ -509,7 +515,7 @@ describe('Trigger.Basic', () => {
   });
 
   describe('stretch', () => {
-    const createTrigger = stretch =>
+    const createTrigger = (stretch) =>
       mount(
         <Trigger
           action={['click']}
@@ -542,7 +548,7 @@ describe('Trigger.Basic', () => {
       domSpy.mockRestore();
     });
 
-    ['width', 'height', 'minWidth', 'minHeight'].forEach(prop => {
+    ['width', 'height', 'minWidth', 'minHeight'].forEach((prop) => {
       it(prop, () => {
         const wrapper = createTrigger(prop);
 
@@ -643,7 +649,7 @@ describe('Trigger.Basic', () => {
           <div>
             <button
               type="button"
-              onMouseDown={e => {
+              onMouseDown={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
               }}
@@ -687,7 +693,7 @@ describe('Trigger.Basic', () => {
 
   describe('getContainer', () => {
     it('not trigger when dom not ready', () => {
-      const getPopupContainer = jest.fn(node => node.parentElement);
+      const getPopupContainer = jest.fn((node) => node.parentElement);
 
       function Demo() {
         return (


### PR DESCRIPTION
related issue:
https://github.com/ant-design/ant-design/issues/29853

I didn't check showAction or hideAction in isContextMenuOnly(), because when those 2 are defined, user might have very specific expectation about the mouse behavior, so I don't want to break existing code.