### PR TITLE
fix: keep parent in strict mode

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -563,7 +563,7 @@ export function generateTrigger(
       );
     };
 
-    attachParent = (popupContainer: HTMLDivElement) => {
+    attachParent = (popupContainer: HTMLElement) => {
       raf.cancel(this.attachId);
 
       const { getPopupContainer, getDocument } = this.props;
@@ -606,11 +606,11 @@ export function generateTrigger(
         popupContainer.style.top = '0';
         popupContainer.style.left = '0';
         popupContainer.style.width = '100%';
-        this.attachParent(popupContainer);
 
         this.portalContainer = popupContainer;
       }
 
+      this.attachParent(this.portalContainer);
       return this.portalContainer;
     };
 

--- a/tests/basic.test.jsx
+++ b/tests/basic.test.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable max-classes-per-file */
 
-import React, { createRef } from 'react';
+import React, { StrictMode, createRef } from 'react';
 import ReactDOM from 'react-dom';
 import { act, cleanup, fireEvent, render } from '@testing-library/react';
 import { spyElementPrototypes } from 'rc-util/lib/test/domHook';
@@ -819,5 +819,24 @@ describe('Trigger.Basic', () => {
 
     expect(isChildUpdate).toBeFalsy();
     expect(isGrandsonUpdate).toBeFalsy();
+  });
+
+  it('should work in StrictMode with autoDestroy', () => {
+    const { container } = render(
+      <Trigger action={['click']} autoDestroy={true}>
+        <div className="target">click</div>
+      </Trigger>,
+      { wrapper: StrictMode },
+    );
+
+    // click to show
+    trigger(container, '.target');
+    expect(document.querySelector('.rc-trigger-popup')).toBeTruthy();
+    // click to hide
+    trigger(container, '.target');
+    expect(document.querySelector('.rc-trigger-popup')).toBeFalsy();
+    // click to show
+    trigger(container, '.target');
+    expect(document.querySelector('.rc-trigger-popup')).toBeTruthy();
   });
 });


### PR DESCRIPTION
fix for `keepParent: false`, portal container should be attached to parent.

```tsx
<Tooltip
  title="Antd Tooltip"
  destroyTooltipOnHide={{ keepParent: false }}
>
  <span>Antd Tooltip</span>
</Tooltip>
```