### PR TITLE
fix: only disappearing elements should not be interactive

### DIFF
--- a/src/Popup/PopupInner.tsx
+++ b/src/Popup/PopupInner.tsx
@@ -184,7 +184,7 @@ const PopupInner = React.forwardRef<PopupInnerRef, PopupInnerProps>(
         status === 'motion' || status === 'stable' || !visible ? undefined : 0,
       // Cannot interact with disappearing elements
       // https://github.com/ant-design/ant-design/issues/35051#issuecomment-1101340714
-      pointerEvents: !visible && status === 'motion' ? 'none' : undefined,
+      pointerEvents: !visible && status !== 'stable' ? 'none' : undefined,
       ...style,
     };
 

--- a/src/Popup/PopupInner.tsx
+++ b/src/Popup/PopupInner.tsx
@@ -182,7 +182,9 @@ const PopupInner = React.forwardRef<PopupInnerRef, PopupInnerProps>(
       zIndex,
       opacity:
         status === 'motion' || status === 'stable' || !visible ? undefined : 0,
-      pointerEvents: status === 'stable' ? undefined : 'none',
+      // Cannot interact with disappearing elements
+      // https://github.com/ant-design/ant-design/issues/35051#issuecomment-1101340714
+      pointerEvents: !visible && status === 'motion' ? 'none' : undefined,
       ...style,
     };
 

--- a/tests/motion.test.jsx
+++ b/tests/motion.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { cleanup, fireEvent, render } from '@testing-library/react';
+import { act, cleanup, fireEvent, render } from '@testing-library/react';
 import Trigger from '../src';
 import CSSMotion from 'rc-motion';
 import { placementAlignMap } from './util';
@@ -63,5 +63,31 @@ describe('Trigger.Motion', () => {
       expect.objectContaining({ leavedClassName: 'light' }),
       expect.anything(),
     );
+  });
+
+  it('not lock on appear', () => {
+    const genTrigger = (props) => (
+      <Trigger
+        popup={<strong className="x-content" />}
+        popupMotion={{
+          motionName: 'bamboo',
+        }}
+        popupVisible
+        {...props}
+      >
+        <span />
+      </Trigger>
+    );
+
+    const { rerender } = render(genTrigger());
+
+    expect(document.querySelector('.rc-trigger-popup')).not.toHaveStyle({
+      pointerEvents: 'none',
+    });
+
+    rerender(genTrigger({ popupVisible: false }));
+    expect(document.querySelector('.rc-trigger-popup')).toHaveStyle({
+      pointerEvents: 'none',
+    });
   });
 });

--- a/tests/motion.test.jsx
+++ b/tests/motion.test.jsx
@@ -34,6 +34,10 @@ describe('Trigger.Motion', () => {
     expect(document.querySelector('.rc-trigger-popup')).toHaveClass(
       'bamboo-appear',
     );
+
+    expect(
+      document.querySelector('.rc-trigger-popup').style.pointerEvents,
+    ).toEqual('');
   });
 
   it('use correct leave motion', () => {

--- a/tests/util.test.jsx
+++ b/tests/util.test.jsx
@@ -84,7 +84,7 @@ describe('Trigger.Util', () => {
       );
 
       expect(container.innerHTML).toEqual(
-        '<div>light</div><div><div class="rc-trigger-popup" style="opacity: 0; pointer-events: none;"><div>bamboo</div></div></div>',
+        '<div>light</div><div><div class="rc-trigger-popup" style="opacity: 0;"><div>bamboo</div></div></div>',
       );
     });
   });


### PR DESCRIPTION
https://github.com/ant-design/ant-design/issues/35051#issuecomment-1101340714

消失的动画出不来，所以这个测试用例没补（消失时应该有 `pointer-events: none`），看上去需要 mock rc-motion ？

@zombieJ 看看