### PR TITLE
fix: Align not waiting

### DIFF
--- a/src/Popup/PopupInner.tsx
+++ b/src/Popup/PopupInner.tsx
@@ -102,6 +102,14 @@ const PopupInner = React.forwardRef<PopupInnerRef, PopupInnerProps>(
     const [status, goNextStatus] = useVisibleStatus(visible, doMeasure);
 
     // ======================== Aligns ========================
+    /**
+     * `alignedClassName` may modify `source` size,
+     * which means one time align may not move to the correct position at once.
+     *
+     * We will reset `alignTimes` for each status switch to `alignPre`
+     * and let `rc-align` to align for multiple times to ensure get final stable place.
+     * Currently we mark `alignTimes < 2` repeat align, it will increase if user report for align issue.
+     */
     const [alignTimes, setAlignTimes] = useState(0);
     const prepareResolveRef = useRef<(value?: unknown) => void>();
 

--- a/src/Popup/useVisibleStatus.ts
+++ b/src/Popup/useVisibleStatus.ts
@@ -12,11 +12,24 @@ import useState from 'rc-util/lib/hooks/useState';
  * motion - play the motion
  * stable - everything is done
  */
-type PopupStatus = null | 'measure' | 'align' | 'aligned' | 'motion' | 'stable';
+type PopupStatus =
+  | null
+  | 'measure'
+  | 'alignPre'
+  | 'align'
+  | 'aligned'
+  | 'motion'
+  | 'stable';
 
 type Func = () => void;
 
-const StatusQueue: PopupStatus[] = ['measure', 'align', null, 'motion'];
+const StatusQueue: PopupStatus[] = [
+  'measure',
+  'alignPre',
+  'align',
+  null,
+  'motion',
+];
 
 export default (
   visible: boolean,

--- a/tests/point.test.jsx
+++ b/tests/point.test.jsx
@@ -38,7 +38,11 @@ describe('Trigger.Point', () => {
   function trigger(container, eventName, data) {
     const pointRegion = container.querySelector('.point-region');
     fireEvent(pointRegion, getMouseEvent(eventName, data));
-    act(() => jest.runAllTimers());
+
+    // React scheduler will not hold when useEffect. We need repeat to tell that times go
+    for (let i = 0; i < 10; i += 1) {
+      act(() => jest.runAllTimers());
+    }
   }
 
   it('onClick', async () => {


### PR DESCRIPTION
resolve https://github.com/ant-design/ant-design/issues/35197

`rc-align` 触发事件后，`rc-trigger` 本身做一个计数器。每次 align 后增加，重试 3 次后即进入下一个阶段。无论当前是否真的对齐到了预期位置。

antd 的问题在于对齐初期没有箭头，当对齐完毕后增加箭头，这个时候导致高度产生了变化让原本对齐的位置失效。过去为同步方法，在失效后进行重试，位置不再变化后进入下一个阶段。而在 React 18 StrictMode 下，同步执行由于不保证 forceAlign 导致成为了死循环。而改成异步 effect 后则不知道什么时候是最终对齐态。此处则增加一个 effect 计数器让数据流可以等待，并且最终会强制走到下一个阶段。