### PR TITLE
support hideContextMenuOnScroll option

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,12 @@ npm start
           <td></td>
           <td>Let popup div stretch with trigger element. enums of 'width', 'minWidth', 'height', 'minHeight'. (You can also mixed with 'height minWidth')</td>
         </tr>
+        <tr>
+          <td>hideContextMenuOnScroll</td>
+          <td>boolean</td>
+          <td>true</td>
+          <td>close popup when trigger type contains 'onContextMenu' and document is scrolling</td>
+        </tr>
     </tbody>
 </table>
 

--- a/docs/examples/case.tsx
+++ b/docs/examples/case.tsx
@@ -217,6 +217,7 @@ const Demo = () => {
             onPopupAlign={() => {
               console.warn('Aligned!');
             }}
+            hideContextMenuOnScroll={false}
           >
             <div
               style={{

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -84,6 +84,7 @@ export interface TriggerProps {
   popupVisible?: boolean;
   defaultPopupVisible?: boolean;
   autoDestroy?: boolean;
+  hideContextMenuOnScroll?: boolean;
 
   stretch?: string;
   alignPoint?: boolean; // Maybe we can support user pass position in the future
@@ -151,6 +152,7 @@ export function generateTrigger(
       showAction: [],
       hideAction: [],
       autoDestroy: false,
+      hideContextMenuOnScroll: true,
     };
 
     popupRef = React.createRef<PopupInnerRef>();
@@ -240,7 +242,7 @@ export function generateTrigger(
           );
         }
         // close popup when trigger type contains 'onContextMenu' and document is scrolling.
-        if (!this.contextMenuOutsideHandler1 && this.isContextMenuToShow()) {
+        if (props.hideContextMenuOnScroll && !this.contextMenuOutsideHandler1 && this.isContextMenuToShow()) {
           currentDocument =
             currentDocument || props.getDocument(this.getRootDomNode());
           this.contextMenuOutsideHandler1 = addEventListener(


### PR DESCRIPTION
In some scenarios, we may want the context menu to remain displayed when the page scroll. 

For example, the context menu is longer than the viewport, and the user needs to scroll to see all the context menu options.