### PR TITLE
chore: adjust retry times

### DIFF
--- a/.fatherrc.js
+++ b/.fatherrc.js
@@ -1,9 +1,5 @@
-export default {
-  cjs: 'babel',
-  esm: { type: 'babel', importLibToEs: true },
-  preCommit: {
-    eslint: true,
-    prettier: true,
-  },
-  runtimeHelpers: true,
-};
+import { defineConfig } from 'father';
+
+export default defineConfig({
+  plugins: ['@rc-component/father-plugin'],
+});

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v1
         with:
-          node-version: '12'
+          node-version: '16'
 
       - name: cache package-lock.json
         uses: actions/cache@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: install
         if: steps.node_modules_cache_id.outputs.cache-hit != 'true'
-        run: npm ci
+        run: npm i
   
   lint:
     runs-on: ubuntu-latest

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,3 @@
 module.exports = {
   setupFiles: ['./tests/setup.js'],
-  setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect'],
 };

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "prepublishOnly": "npm run compile && np --yolo --no-publish",
     "lint": "eslint src/ docs/examples/ --ext .tsx,.ts,.jsx,.js",
     "test": "rc-test",
-    "coverage": "father test --coverage",
+    "coverage": "rc-test -- --coverage",
     "now-build": "npm run build"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "compile": "father build && lessc assets/index.less assets/index.css",
     "prepublishOnly": "npm run compile && np --yolo --no-publish",
     "lint": "eslint src/ docs/examples/ --ext .tsx,.ts,.jsx,.js",
-    "test": "father test",
+    "test": "rc-test",
     "coverage": "father test --coverage",
     "now-build": "npm run build"
   },
@@ -49,13 +49,15 @@
     "cross-env": "^7.0.1",
     "dumi": "^1.1.38",
     "eslint": "^7.0.0",
-    "father": "^2.30.2",
+    "father": "^4.0.0",
     "less": "^3.10.3",
     "np": "^6.2.0",
+    "rc-test": "^7.0.11",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "regenerator-runtime": "^0.13.7",
-    "typescript": "^4.0.0"
+    "typescript": "^4.0.0",
+    "@rc-component/father-plugin": "^1.0.0"
   },
   "dependencies": {
     "@babel/runtime": "^7.18.3",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "father": "^4.0.0",
     "less": "^3.10.3",
     "np": "^6.2.0",
-    "rc-test": "^7.0.12",
+    "rc-test": "^7.0.13",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "regenerator-runtime": "^0.13.7",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "prepublishOnly": "npm run compile && np --yolo --no-publish",
     "lint": "eslint src/ docs/examples/ --ext .tsx,.ts,.jsx,.js",
     "test": "rc-test",
-    "coverage": "rc-test -- --coverage",
+    "coverage": "rc-test --coverage",
     "now-build": "npm run build"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "father": "^4.0.0",
     "less": "^3.10.3",
     "np": "^6.2.0",
-    "rc-test": "^7.0.11",
+    "rc-test": "^7.0.12",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "regenerator-runtime": "^0.13.7",

--- a/src/Popup/PopupInner.tsx
+++ b/src/Popup/PopupInner.tsx
@@ -111,6 +111,11 @@ const PopupInner = React.forwardRef<PopupInnerRef, PopupInnerProps>(
      * We will reset `alignTimes` for each status switch to `alignPre`
      * and let `rc-align` to align for multiple times to ensure get final stable place.
      * Currently we mark `alignTimes < 2` repeat align, it will increase if user report for align issue.
+     * 
+     * Update:
+     * In React 18. `rc-align` effect of align may faster than ref called trigger `forceAlign`.
+     * We adjust this to `alignTimes < 2`.
+     * We need refactor `rc-align` to support mark of `forceAlign` call if this still happen.
      */
     const [alignTimes, setAlignTimes] = useState(0);
     const prepareResolveRef = useRef<(value?: unknown) => void>();

--- a/src/Popup/PopupInner.tsx
+++ b/src/Popup/PopupInner.tsx
@@ -153,7 +153,7 @@ const PopupInner = React.forwardRef<PopupInnerRef, PopupInnerProps>(
     useLayoutEffect(() => {
       if (status === 'align') {
         // Repeat until not more align needed
-        if (alignTimes < 2) {
+        if (alignTimes < 3) {
           forceAlign();
         } else {
           goNextStatus(function () {

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,9 +1,3 @@
-require('regenerator-runtime/runtime');
-
-window.requestAnimationFrame = (func) => {
-  window.setTimeout(func, 16);
-};
-
 // jsdom add motion events to test CSSMotion
 window.AnimationEvent = window.AnimationEvent || (() => {});
 window.TransitionEvent = window.TransitionEvent || (() => {});


### PR DESCRIPTION
`dom-align` 由于是 React 生命周期之外，性能越差的情况下越可能出现不同步的问题。加1次 retry times。