### PR TITLE
fix: TS export compile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rc-trigger",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "description": "base abstract trigger component for react",
   "engines": {
     "node": ">=8.x"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -901,6 +901,6 @@ export function generateTrigger(
   return Trigger;
 }
 
-export { BuildInPlacements };
+export type { BuildInPlacements };
 
 export default generateTrigger(Portal);


### PR DESCRIPTION
BuildInPlacements 定义被错误当成 export 实体到了 `index.js` 而不是只在 `index.d.ts` 里，诡异