### PR TITLE
fix: TS export compile

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -901,6 +901,6 @@ export function generateTrigger(
   return Trigger;
 }
 
-export { BuildInPlacements };
+export type { BuildInPlacements };
 
 export default generateTrigger(Portal);


### PR DESCRIPTION
BuildInPlacements 定义被错误当成 export 实体到了 index.js 而不是只在 index.d.ts 里，诡异