### PR TITLE
refactor: adjust popupAlign after placement to align with origin logic

### DIFF
--- a/src/hooks/useAlign.ts
+++ b/src/hooks/useAlign.ts
@@ -204,7 +204,7 @@ export default function useAlign(
 
       // Placement
       const placementInfo: AlignType =
-        popupAlign || builtinPlacements[placement] || {};
+        builtinPlacements[placement] || popupAlign || {};
 
       // Offset
       const { offset, targetOffset } = placementInfo;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -358,9 +358,11 @@ export function generateTrigger(
       triggerAlign();
     }, [mousePos]);
 
+    // When no builtinPlacements and popupAlign changed
     useLayoutEffect(() => {
-      if(!mergedOpen) return;
-      triggerAlign();
+      if (mergedOpen && !builtinPlacements?.[popupPlacement]) {
+        triggerAlign();
+      }
     }, [JSON.stringify(popupAlign)]);
 
     const alignedClassName = React.useMemo(() => {

--- a/tests/align.test.tsx
+++ b/tests/align.test.tsx
@@ -3,7 +3,7 @@ import { spyElementPrototypes } from 'rc-util/lib/test/domHook';
 import React from 'react';
 import type { TriggerProps } from '../src';
 import Trigger from '../src';
-import { awaitFakeTimer } from "./util";
+import { awaitFakeTimer } from './util';
 
 import { _rs } from 'rc-resize-observer';
 
@@ -107,5 +107,27 @@ describe('Trigger.Align', () => {
 
     await awaitFakeTimer();
     expect(onAlign).toHaveBeenCalled();
+  });
+
+  it('placement is higher than popupAlign', async () => {
+    render(
+      <Trigger
+        popupVisible
+        popup={<span className="bamboo" />}
+        builtinPlacements={{
+          top: {},
+        }}
+        popupPlacement="top"
+        popupAlign={{}}
+      >
+        <span />
+      </Trigger>,
+    );
+
+    await awaitFakeTimer();
+
+    expect(
+      document.querySelector('.rc-trigger-popup-placement-top'),
+    ).toBeTruthy();
   });
 });


### PR DESCRIPTION
和 `rc-trigger@5` 保持一致