### PR TITLE
fix: 针对小数类型的偏移量进行四舍五入解决小数导致箭头与弹框分裂的问题

### DIFF
--- a/src/hooks/useAlign.ts
+++ b/src/hooks/useAlign.ts
@@ -388,10 +388,10 @@ export default function useAlign(
 
       setOffsetInfo({
         ready: true,
-        offsetX: nextOffsetX / scaleX,
-        offsetY: nextOffsetY / scaleY,
-        arrowX: nextArrowX / scaleX,
-        arrowY: nextArrowY / scaleY,
+        offsetX: Math.round(nextOffsetX / scaleX),
+        offsetY: Math.round(nextOffsetY / scaleY),
+        arrowX: Math.round(nextArrowX / scaleX),
+        arrowY: Math.round(nextArrowY / scaleY),
         scaleX,
         scaleY,
         align: nextAlignInfo,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10286961/220070025-c89a05d4-5409-4e37-bcc2-779a6bab449d.png)
