### PR TITLE
chore: ignore body rect

### DIFF
--- a/docs/demos/body-overflow.md
+++ b/docs/demos/body-overflow.md
@@ -1,0 +1,8 @@
+---
+title: Body Overflow
+nav:
+  title: Demo
+  path: /demo
+---
+
+<code src="../examples/body-overflow.tsx"></code>

--- a/docs/examples/body-overflow.tsx
+++ b/docs/examples/body-overflow.tsx
@@ -1,0 +1,63 @@
+/* eslint no-console:0 */
+import Trigger from 'rc-trigger';
+import React from 'react';
+import '../../assets/index.less';
+
+export default () => {
+  return (
+    <React.StrictMode>
+      <style
+        dangerouslySetInnerHTML={{
+          __html: `
+        body {
+          overflow-x: hidden;
+        }
+      `,
+        }}
+      />
+
+      <Trigger
+        arrow
+        // forceRender
+        action="click"
+        popup={
+          <div
+            style={{
+              background: 'yellow',
+              border: '1px solid blue',
+              width: 200,
+              height: 60,
+              opacity: 0.9,
+            }}
+          >
+            Popup
+          </div>
+        }
+        popupStyle={{ boxShadow: '0 0 5px red' }}
+        popupAlign={{
+          points: ['tc', 'bc'],
+          overflow: {
+            shiftX: 50,
+            adjustY: true,
+          },
+          offset: [0, -10],
+          htmlRegion: 'scroll',
+        }}
+      >
+        <span
+          style={{
+            background: 'green',
+            color: '#FFF',
+            paddingBlock: 30,
+            paddingInline: 70,
+            opacity: 0.9,
+            transform: 'scale(0.6)',
+            display: 'inline-block',
+          }}
+        >
+          Target
+        </span>
+      </Trigger>
+    </React.StrictMode>
+  );
+};

--- a/src/hooks/useAlign.ts
+++ b/src/hooks/useAlign.ts
@@ -191,6 +191,10 @@ export default function useAlign(
             };
 
       (scrollerList || []).forEach((ele) => {
+        if (ele instanceof HTMLBodyElement) {
+          return;
+        }
+
         const eleRect = ele.getBoundingClientRect();
         const {
           offsetHeight: eleOutHeight,


### PR DESCRIPTION
antd 站点有个 body 的 `overflow: hidden` 导致计算可见区域的时候被裁剪：
https://ant.design/~demos/components-select-demo-basic