### PR TITLE
fix: ref check to avoid loop

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,10 +2,10 @@ import Portal from '@rc-component/portal';
 import classNames from 'classnames';
 import type { CSSMotionProps } from 'rc-motion';
 import ResizeObserver from 'rc-resize-observer';
+import { isDOM } from 'rc-util/lib/Dom/findDOMNode';
 import useEvent from 'rc-util/lib/hooks/useEvent';
 import useId from 'rc-util/lib/hooks/useId';
 import useLayoutEffect from 'rc-util/lib/hooks/useLayoutEffect';
-import { isDOM } from 'rc-util/lib/Dom/findDOMNode';
 import * as React from 'react';
 import type { TriggerContextProps } from './context';
 import TriggerContext from './context';
@@ -214,23 +214,23 @@ export function generateTrigger(
     const id = useId();
     const [popupEle, setPopupEle] = React.useState<HTMLDivElement>(null);
 
-    const setPopupRef = React.useCallback((node: HTMLDivElement) => {
-      if (isDOM(node)) {
+    const setPopupRef = useEvent((node: HTMLDivElement) => {
+      if (isDOM(node) && popupEle !== node) {
         setPopupEle(node);
       }
 
       parentContext?.registerSubPopup(id, node);
-    }, []);
+    });
 
     // =========================== Target ===========================
     // Use state to control here since `useRef` update not trigger render
     const [targetEle, setTargetEle] = React.useState<HTMLElement>(null);
 
-    const setTargetRef = React.useCallback((node: HTMLElement) => {
-      if (isDOM(node)) {
+    const setTargetRef = useEvent((node: HTMLElement) => {
+      if (isDOM(node) && targetEle !== node) {
         setTargetEle(node);
       }
-    }, []);
+    });
 
     // ========================== Children ==========================
     const child = React.Children.only(children) as React.ReactElement;


### PR DESCRIPTION
resolve https://github.com/ant-design/ant-design/issues/41261

ref 调用 setState 会触发 rerender，在快速切换时 React 18 会将 batch 合并，这使得 setState 的 prev 一直是 null 会让 React 认为是 `null -> node` 状态导致死循环。测试环境模拟不出来这种情况。比较蛋疼。