### PR TITLE
fix: popup shift to left in the first render when set strech property to trigger

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -345,6 +345,13 @@ export function generateTrigger(
     useLayoutEffect(
       (firstMount) => {
         if (!firstMount || mergedOpen) {
+          if (stretch) {
+            // delay setting makes it calculate
+            setTimeout(() => {
+              setInMotion(true);
+            }, 0);
+            return;
+          }
           setInMotion(true);
         }
       },


### PR DESCRIPTION
![image](https://github.com/react-component/trigger/assets/102608263/0b8f6447-2a0d-4a4a-979b-bb1f766a8171)
![image](https://github.com/react-component/trigger/assets/102608263/4d8be7d5-eda3-4803-9756-93a3e7ce6857)
the value of inMotion stop the triggerAlign when first set width to popup, need set it to false

fix https://github.com/ant-design/ant-design/issues/44249