### PR TITLE
fix: align jump for the first time render

### DIFF
--- a/docs/examples/simple.tsx
+++ b/docs/examples/simple.tsx
@@ -69,7 +69,7 @@ const RefTarget = React.forwardRef((props, ref) => {
 interface TestState {
   mask: boolean;
   maskClosable: boolean;
-  placement: 'right';
+  placement: string;
   trigger: {
     click?: boolean;
     focus?: boolean;
@@ -90,13 +90,13 @@ class Test extends React.Component<any, TestState> {
   state: TestState = {
     mask: true,
     maskClosable: true,
-    placement: 'right',
+    placement: 'bottom',
     trigger: {
       click: true,
     },
     offsetX: undefined,
     offsetY: undefined,
-    stretch: '',
+    stretch: 'minWidth',
     transitionName: 'rc-trigger-popup-zoom',
   };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -444,6 +444,23 @@ export function generateTrigger(
       forceAlign: triggerAlign,
     }));
 
+    // ========================== Stretch ===========================
+    const [targetWidth, setTargetWidth] = React.useState(0);
+    const [targetHeight, setTargetHeight] = React.useState(0);
+
+    const syncTargetSize = () => {
+      if (stretch && targetEle) {
+        const rect = targetEle.getBoundingClientRect();
+        setTargetWidth(rect.width);
+        setTargetHeight(rect.height);
+      }
+    };
+
+    const onTargetResize = () => {
+      triggerAlign();
+      syncTargetSize();
+    };
+
     // ========================== Motion ============================
     const onVisibleChanged = (visible: boolean) => {
       setInMotion(false);
@@ -454,6 +471,7 @@ export function generateTrigger(
     // We will trigger align when motion is in prepare
     const onPrepare = () =>
       new Promise<void>((resolve) => {
+        syncTargetSize();
         setMotionPrepareResolve(() => resolve);
       });
 
@@ -464,20 +482,6 @@ export function generateTrigger(
         setMotionPrepareResolve(null);
       }
     }, [motionPrepareResolve]);
-
-    // ========================== Stretch ===========================
-    const [targetWidth, setTargetWidth] = React.useState(0);
-    const [targetHeight, setTargetHeight] = React.useState(0);
-
-    const onTargetResize = (_: object, ele: HTMLElement) => {
-      triggerAlign();
-
-      if (stretch) {
-        const rect = ele.getBoundingClientRect();
-        setTargetWidth(rect.width);
-        setTargetHeight(rect.height);
-      }
-    };
 
     // =========================== Action ===========================
     /**

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -457,8 +457,8 @@ export function generateTrigger(
     };
 
     const onTargetResize = () => {
-      triggerAlign();
       syncTargetSize();
+      triggerAlign();
     };
 
     // ========================== Motion ============================

--- a/tests/basic.test.jsx
+++ b/tests/basic.test.jsx
@@ -561,9 +561,7 @@ describe('Trigger.Basic', () => {
         it(`${
           mockRect ? 'offset' : 'getBoundingClientRect'
         }: ${prop}`, async () => {
-          const onPopupAlign = jest.fn(() => {
-            expect(rectCalled).toBeTruthy();
-          });
+          const onPopupAlign = jest.fn();
 
           const { container } = createTrigger(prop, {
             onPopupAlign,
@@ -573,15 +571,15 @@ describe('Trigger.Basic', () => {
           expect(rectCalled).toBeFalsy();
           expect(onPopupAlign).not.toHaveBeenCalled();
 
+          // Click will trigger `onPrepare` which need measure target size
           fireEvent.click(container.querySelector('.target'));
-          for (let i = 0; i < 10; i += 1) {
-            await act(async () => {
-              jest.advanceTimersByTime(100);
-              await Promise.resolve();
-            });
-          }
-
           expect(rectCalled).toBeTruthy();
+
+          // Flush for motion
+          await act(async () => {
+            jest.advanceTimersByTime(100);
+            await Promise.resolve();
+          });
           expect(onPopupAlign).toHaveBeenCalled();
 
           expect(


### PR DESCRIPTION
在过去版本有个 queue 做状态管理，会确保在对齐前做一次 stretch 对齐，重写后这部分丢失。在 onPrepare 阶段补上对齐逻辑。

close https://github.com/react-component/trigger/pull/420
fix https://github.com/ant-design/ant-design/issues/44249

cc @bbb169