### PR TITLE
chore: compatible for React16

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,7 +9,6 @@ import useId from 'rc-util/lib/hooks/useId';
 import useLayoutEffect from 'rc-util/lib/hooks/useLayoutEffect';
 import isMobile from 'rc-util/lib/isMobile';
 import * as React from 'react';
-import { flushSync } from 'react-dom';
 import Popup from './Popup';
 import TriggerWrapper from './TriggerWrapper';
 import type { TriggerContextProps } from './context';
@@ -320,15 +319,21 @@ export function generateTrigger(
     const openRef = React.useRef(mergedOpen);
     openRef.current = mergedOpen;
 
+    const lastTriggerRef = React.useRef([]);
+    lastTriggerRef.current = [];
+
     const internalTriggerOpen = useEvent((nextOpen: boolean) => {
+      setMergedOpen(nextOpen);
+
       // Enter or Pointer will both trigger open state change
       // We only need take one to avoid duplicated change event trigger
-      flushSync(() => {
-        if (mergedOpen !== nextOpen) {
-          setMergedOpen(nextOpen);
-          onPopupVisibleChange?.(nextOpen);
-        }
-      });
+      // Use `lastTriggerRef` to record last open type
+      if (
+        lastTriggerRef.current[lastTriggerRef.current.length - 1] !== nextOpen
+      ) {
+        lastTriggerRef.current.push(nextOpen);
+        onPopupVisibleChange?.(nextOpen);
+      }
     });
 
     // Trigger for delay

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -319,7 +319,7 @@ export function generateTrigger(
     const openRef = React.useRef(mergedOpen);
     openRef.current = mergedOpen;
 
-    const lastTriggerRef = React.useRef([]);
+    const lastTriggerRef = React.useRef<boolean[]>([]);
     lastTriggerRef.current = [];
 
     const internalTriggerOpen = useEvent((nextOpen: boolean) => {


### PR DESCRIPTION
### 背景

在 https://github.com/ant-design/ant-design/pull/45653 的 PR 中，为组件添加 `autoFocus` 事件导致在 React 16 的 test case 中不会触发 `onFocus` 事件。

### 问题由来

为错误打 console 可以发现，React 内部已经触发了 `react-focus` 事件。问题是 React 16 没有把这个事件正确触发。

<img width="675" alt="截屏2023-11-03 23 12 59" src="https://github.com/react-component/trigger/assets/5378891/ca70f812-50ef-4aeb-b38e-198a95c8f015">

错误信息来自于 `rc-trigger` 调用了 `flushSync` 导致生命周期报错。


### 相关部分

#### rc-slider

`autoFocus` 属性会通过 `useEffect` 触发 `handleRef.current.focus` 方法触发聚焦。

#### rc-trigger

`rc-trigger` 对 `action` 标记为 `focus` 的事件添加监听事件，并且触发对应的 `triggerOpen` 逻辑。

在 #415 中，`rc-trigger` 为支持 `disabled` 元素也能触发 `open` 而同时兼容旧版不支持 `pointerEvent` 浏览器所以同时保留了 `mouseEvent` 监听。所以当元素被悬浮时，会触发 `onPointerEnter` 和 `onMouseEnter` 事件。

而在 React 18 中，这两个事件会被 batch update。导致通过 `open` 是否变化来判断要触发 `onOpenChange` 的事件因为闭包问题导致会触发两次。所以在 #415 中，使用了 `flushSync` 确保两个事件之间不被 batch update 掉。

### 报错原因

`useEffect` 中触发的 `focus` 事件调用 `focus` 并触发 `rc-trigger` 的 `triggerOpen` 方法后调用 `flushSync` 事件。在 React 16 中，`useEffect` 被视为生命周期进行中，导致在此不允许调用 `flushSync`。而在 React 18，`useEffect` 中不再视为上一个 render 的生命周期，因而 `focus` 事件触发的 `flushSync` 不会出现 `flushSync was called from inside a lifecycle method` 错误。

### 解决方案

使用 `useRef` 记录最后触发的 `open` 状态，如果相同就不再触发。该 `ref` 每次 render 都会被重置。