### PR TITLE
fix: cut logic of measure

### DIFF
--- a/src/hooks/useAlign.ts
+++ b/src/hooks/useAlign.ts
@@ -177,6 +177,7 @@ export default function useAlign(
       const originTop = popupElement.style.top;
       const originRight = popupElement.style.right;
       const originBottom = popupElement.style.bottom;
+      const originOverflow = popupElement.style.overflow;
 
       // Placement
       const placementInfo: AlignType = {
@@ -198,6 +199,7 @@ export default function useAlign(
       popupElement.style.top = '0';
       popupElement.style.right = 'auto';
       popupElement.style.bottom = 'auto';
+      popupElement.style.overflow = 'hidden';
 
       // Calculate align style, we should consider `transform` case
       let targetRect: Rect;
@@ -281,6 +283,7 @@ export default function useAlign(
       popupElement.style.top = originTop;
       popupElement.style.right = originRight;
       popupElement.style.bottom = originBottom;
+      popupElement.style.overflow = originOverflow;
 
       popupElement.parentElement?.removeChild(placeholderElement);
 
@@ -671,6 +674,8 @@ export default function useAlign(
         popupMirrorRect.right - popupRect.x - (nextOffsetX + popupRect.width);
       const offsetY4Bottom =
         popupMirrorRect.bottom - popupRect.y - (nextOffsetY + popupRect.height);
+
+      debugger;
 
       setOffsetInfo({
         ready: true,


### PR DESCRIPTION
当 Popup 贴底做测量统计时，如果 Popup 有元素是超出 Popup 宽高的会导致游览器出现滚动条。而当回复原来位置后，滚动条消失导致偏了一个滚动条的尺寸。

ref https://github.com/ant-design/ant-design/issues/45784