### PR TITLE
fix: popup position for point-aligned popups when no mouse position is known

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -397,7 +397,7 @@ export function generateTrigger(
     ] = useAlign(
       mergedOpen,
       popupEle,
-      alignPoint && mousePos != null ? mousePos : targetEle,
+      alignPoint && mousePos !== null ? mousePos : targetEle,
       popupPlacement,
       builtinPlacements,
       popupAlign,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -374,9 +374,7 @@ export function generateTrigger(
       React.useState<VoidFunction>(null);
 
     // =========================== Align ============================
-    const [mousePos, setMousePos] = React.useState<[x: number, y: number]>([
-      0, 0,
-    ]);
+    const [mousePos, setMousePos] = React.useState<[x: number, y: number] | null>(null);
 
     const setMousePosByEvent = (
       event: Pick<React.MouseEvent, 'clientX' | 'clientY'>,
@@ -399,7 +397,7 @@ export function generateTrigger(
     ] = useAlign(
       mergedOpen,
       popupEle,
-      alignPoint ? mousePos : targetEle,
+      alignPoint && mousePos != null ? mousePos : targetEle,
       popupPlacement,
       builtinPlacements,
       popupAlign,


### PR DESCRIPTION
When setting `popupVisible` of a `<Trigger />` to true in a controlled manner, the popup is shown at 0,0 of the current page instead of being placed around its actual target. The reason for this is that the mouse position is initialized to 0, 0 and then passed along to `useAlign`.
This is a regression that was introduced in 848a197. In 7590937 this used to work and it had the exact logic I now re-added.

Within 848a197, the missing null initialization was introduced here:
https://github.com/react-component/trigger/commit/848a197f2236f6f5af94cc44e658bebae53837ae#diff-0b5adbfe7b36e4ae2f479291e20152e33e940f7f265162d77f40f6bdb5da7405R310
And here's the conditional passing of the point that was removed: https://github.com/react-component/trigger/commit/848a197f2236f6f5af94cc44e658bebae53837ae#diff-0b5adbfe7b36e4ae2f479291e20152e33e940f7f265162d77f40f6bdb5da7405L542

As a test, I set `popupVisible` to true in rc-trigger/docs/examples/point.tsx so that the popup is rendered by default.

Before:
![image](https://github.com/react-component/trigger/assets/2486553/5d9cfcb5-29f5-4301-b934-b057ee974c33)

After:
![image](https://github.com/react-component/trigger/assets/2486553/eab85ddf-8996-45f5-84bf-441f2f8b04ca)

Would fix https://github.com/ant-design/ant-design/issues/47152.