### PR TITLE
fix: click on shadowDOM popup should not close it

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,6 +1,9 @@
 // global.d.ts
 declare namespace JSX {
   interface IntrinsicElements {
-    'custom-element': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    'custom-element': React.DetailedHTMLProps<
+      React.HTMLAttributes<HTMLElement> & { class?: string }, 
+      HTMLElement
+    >;
   }
 }

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,6 @@
+// global.d.ts
+declare namespace JSX {
+  interface IntrinsicElements {
+    'custom-element': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+  }
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -272,7 +272,7 @@ export function generateTrigger(
     const originChildProps = child?.props || {};
     const cloneProps: typeof originChildProps = {};
 
-    const inContainer = (container: Element, target: Element) => {
+    const inContainer = (target: Element, container: Element) => {
       return (
         target === container ||
         container.contains(target) ||
@@ -283,13 +283,12 @@ export function generateTrigger(
 
     const inPopupOrChild = useEvent((ele: EventTarget) => {
       const childDOM = targetEle;
+      const eleInContainer = inContainer.bind(null, ele as Element);
 
       return (
-        inContainer(childDOM, ele as Element) ||
-        inContainer(popupEle, ele as Element) ||
-        Object.values(subPopupElements.current).some((subPopupEle) =>
-          inContainer(subPopupEle, ele as Element),
-        )
+        eleInContainer(childDOM) ||
+        eleInContainer(popupEle) ||
+        Object.values(subPopupElements.current).some(eleInContainer)
       );
     });
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -272,19 +272,23 @@ export function generateTrigger(
     const originChildProps = child?.props || {};
     const cloneProps: typeof originChildProps = {};
 
+    const inContainer = (container: Element, target: Element) => {
+      return (
+        target === container ||
+        container.contains(target) ||
+        getShadowRoot(container)?.host === target ||
+        container.contains(getShadowRoot(target)?.host)
+      );
+    };
+
     const inPopupOrChild = useEvent((ele: EventTarget) => {
       const childDOM = targetEle;
 
       return (
-        childDOM?.contains(ele as HTMLElement) ||
-        getShadowRoot(childDOM)?.host === ele ||
-        ele === childDOM ||
-        popupEle?.contains(ele as HTMLElement) ||
-        getShadowRoot(popupEle)?.host === ele ||
-        ele === popupEle ||
-        Object.values(subPopupElements.current).some(
-          (subPopupEle) =>
-            subPopupEle?.contains(ele as HTMLElement) || ele === subPopupEle,
+        inContainer(childDOM, ele as Element) ||
+        inContainer(popupEle, ele as Element) ||
+        Object.values(subPopupElements.current).some((subPopupEle) =>
+          inContainer(subPopupEle, ele as Element),
         )
       );
     });

--- a/tests/shadow.test.tsx
+++ b/tests/shadow.test.tsx
@@ -286,7 +286,7 @@ describe('Popup.Shadow', () => {
             autoDestroy
             popup={<custom-element className="popup" />}
           >
-            <custom-element className="target" />
+            <custom-element class="target" />
           </Trigger>
         </>,
       );

--- a/tests/shadow.test.tsx
+++ b/tests/shadow.test.tsx
@@ -235,7 +235,7 @@ describe('Popup.Shadow', () => {
           <Trigger
             action={['click']}
             autoDestroy
-            popup={<custom-element class="popup" />}
+            popup={<custom-element className="popup" />}
           >
             <p className="target" />
           </Trigger>
@@ -284,9 +284,9 @@ describe('Popup.Shadow', () => {
           <Trigger
             action={['click']}
             autoDestroy
-            popup={<custom-element class="popup" />}
+            popup={<custom-element className="popup" />}
           >
-            <custom-element class="target" />
+            <custom-element className="target" />
           </Trigger>
         </>,
       );

--- a/tests/shadow.test.tsx
+++ b/tests/shadow.test.tsx
@@ -235,7 +235,7 @@ describe('Popup.Shadow', () => {
           <Trigger
             action={['click']}
             autoDestroy
-            popup={<custom-element className="popup" />}
+            popup={<custom-element class="popup" />}
           >
             <p className="target" />
           </Trigger>

--- a/tests/shadow.test.tsx
+++ b/tests/shadow.test.tsx
@@ -284,7 +284,7 @@ describe('Popup.Shadow', () => {
           <Trigger
             action={['click']}
             autoDestroy
-            popup={<custom-element className="popup" />}
+            popup={<custom-element class="popup" />}
           >
             <custom-element class="target" />
           </Trigger>


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **修复 bug**
	- 修复了 action 为 click 且 popup 包含 shadowDOM 时，点击 popup 内的 shadowDOM 意外关闭弹窗的问题。
- **重构**
	- 简化了事件目标的容器检查逻辑，提高了代码可读性和可维护性。
- **新功能**
	- 新增了对自定义 JSX 元素 `custom-element` 的支持，增强了与 React 应用的兼容性。
	- 新增了针对 `Popup.Shadow` 组件的测试，确保其在与影子 DOM 元素和自定义组件交互时的正确行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->