### PR TITLE
fix: 弹出窗口因为浏览器窗口变化从bottomLeft对齐到topRight对齐时，箭头对齐错误

### DIFF
--- a/src/hooks/useAlign.ts
+++ b/src/hooks/useAlign.ts
@@ -323,6 +323,8 @@ export default function useAlign(
       const [popupPoint, targetPoint] = placementInfo.points || [];
       const targetPoints = splitPoints(targetPoint);
       const popupPoints = splitPoints(popupPoint);
+      let tmpTargetPoints = targetPoints;
+      let tmpPopupPoints = popupPoints;
 
       const targetAlignPoint = getAlignPoint(targetRect, targetPoints);
       const popupAlignPoint = getAlignPoint(popupRect, popupPoints);
@@ -399,6 +401,11 @@ export default function useAlign(
       }
       syncNextPopupPosition();
 
+      function updateTmpPopupPointsAndTmpTargetPoints() {
+        tmpPopupPoints = splitPoints(nextAlignInfo.points[0]);
+        tmpTargetPoints = splitPoints(nextAlignInfo.points[1]);
+      }
+
       // >>>>>>>>>> Top & Bottom
       const needAdjustY = supportAdjust(adjustY);
 
@@ -443,9 +450,10 @@ export default function useAlign(
           popupOffsetY = -popupOffsetY;
 
           nextAlignInfo.points = [
-            reversePoints(popupPoints, 0),
-            reversePoints(targetPoints, 0),
+            reversePoints(tmpPopupPoints, 0),
+            reversePoints(tmpTargetPoints, 0),
           ];
+          updateTmpPopupPointsAndTmpTargetPoints();
         } else {
           prevFlipRef.current.bt = false;
         }
@@ -489,9 +497,10 @@ export default function useAlign(
           popupOffsetY = -popupOffsetY;
 
           nextAlignInfo.points = [
-            reversePoints(popupPoints, 0),
-            reversePoints(targetPoints, 0),
+            reversePoints(tmpPopupPoints, 0),
+            reversePoints(tmpTargetPoints, 0),
           ];
+          updateTmpPopupPointsAndTmpTargetPoints();
         } else {
           prevFlipRef.current.tb = false;
         }
@@ -542,9 +551,10 @@ export default function useAlign(
           popupOffsetX = -popupOffsetX;
 
           nextAlignInfo.points = [
-            reversePoints(popupPoints, 1),
-            reversePoints(targetPoints, 1),
+            reversePoints(tmpPopupPoints, 1),
+            reversePoints(tmpTargetPoints, 1),
           ];
+          updateTmpPopupPointsAndTmpTargetPoints();
         } else {
           prevFlipRef.current.rl = false;
         }
@@ -588,9 +598,10 @@ export default function useAlign(
           popupOffsetX = -popupOffsetX;
 
           nextAlignInfo.points = [
-            reversePoints(popupPoints, 1),
-            reversePoints(targetPoints, 1),
+            reversePoints(tmpPopupPoints, 1),
+            reversePoints(tmpTargetPoints, 1),
           ];
+          updateTmpPopupPointsAndTmpTargetPoints();
         } else {
           prevFlipRef.current.lr = false;
         }


### PR DESCRIPTION
https://github.com/react-component/picker/pull/886#issuecomment-2452892185
![动画](https://github.com/user-attachments/assets/67cee149-a612-4eb8-9d0f-2294c9aea7b9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 改进了弹出框的对齐逻辑，确保在可见性和交集区域的基础上进行最佳对齐。
  
- **修复**
  - 优化了弹出框位置翻转的条件，提升了对齐的准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->