### PR TITLE
fix: use rc-util `getNodeRef` to resolve React 19 warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "classnames": "^2.3.2",
     "rc-motion": "^2.0.0",
     "rc-resize-observer": "^1.3.1",
-    "rc-util": "^5.38.0"
+    "rc-util": "^5.44.0"
   },
   "peerDependencies": {
     "react": ">=16.9.0",

--- a/src/TriggerWrapper.tsx
+++ b/src/TriggerWrapper.tsx
@@ -1,4 +1,9 @@
-import { fillRef, supportRef, useComposeRef } from 'rc-util/lib/ref';
+import {
+  fillRef,
+  getNodeRef,
+  supportRef,
+  useComposeRef,
+} from 'rc-util/lib/ref';
 import * as React from 'react';
 import type { TriggerProps } from '.';
 
@@ -21,7 +26,7 @@ const TriggerWrapper = React.forwardRef<HTMLElement, TriggerWrapperProps>(
       [getTriggerDOMNode],
     );
 
-    const mergedRef = useComposeRef(setRef, (children as any).ref);
+    const mergedRef = useComposeRef(setRef, getNodeRef(children));
 
     return canUseRef
       ? React.cloneElement(children, {


### PR DESCRIPTION
ref https://github.com/ant-design/ant-design/issues/49267

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 更新了依赖项 `rc-util` 的版本。
	- 在 `TriggerWrapper` 组件中改进了子组件引用的处理方式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->