### PR TITLE
fix: popup glitch when not enough width

### DIFF
--- a/src/hooks/useAlign.ts
+++ b/src/hooks/useAlign.ts
@@ -167,11 +167,7 @@ export default function useAlign(
       const doc = popupElement.ownerDocument;
       const win = getWin(popupElement);
 
-      const {
-        width,
-        height,
-        position: popupPosition,
-      } = win.getComputedStyle(popupElement);
+      const { position: popupPosition } = win.getComputedStyle(popupElement);
 
       const originLeft = popupElement.style.left;
       const originTop = popupElement.style.top;
@@ -222,6 +218,7 @@ export default function useAlign(
         };
       }
       const popupRect = popupElement.getBoundingClientRect();
+      const { height, width } = win.getComputedStyle(popupElement);
       popupRect.x = popupRect.x ?? popupRect.left;
       popupRect.y = popupRect.y ?? popupRect.top;
       const {


### PR DESCRIPTION
This is a fix for #496 which was introduced in https://github.com/react-component/trigger/pull/419

That change moved setting the height/width to before the popupElement reset, which makes the calculations that use height/width incorrect. Moving the height/width assignment back to after the popupElement reset fixes the glitch caused by incorrect calculations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- 优化了弹出窗口尺寸获取和对齐计算的内部逻辑，简化了代码结构。
	- 调整后的处理方案确保窗口显示与定位保持稳定，用户体验不受影响。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->