### PR TITLE
fix: config update logic

### DIFF
--- a/src/Popup/index.tsx
+++ b/src/Popup/index.tsx
@@ -156,7 +156,7 @@ const Popup = React.forwardRef<HTMLDivElement, PopupProps>((props, ref) => {
     }
 
     return [mask, maskMotion, motion];
-  }, [mobile]);
+  }, [mobile, mask, maskMotion, motion]);
 
   // ======================= Container ========================
   const getPopupContainerNeedParams = getPopupContainer?.length > 0;

--- a/tests/motion.test.jsx
+++ b/tests/motion.test.jsx
@@ -140,4 +140,22 @@ describe('Trigger.Motion', () => {
     );
     expect(document.querySelector('.little')).toBeTruthy();
   });
+
+  it('keep motion config update when motion ready', () => {
+    const genTrigger = (props) => (
+      <Trigger popup={<div />} popupMotion={{}} popupVisible {...props}>
+        <span />
+      </Trigger>
+    );
+
+    const { rerender } = render(genTrigger());
+    expect(document.querySelector('.bamboo')).toBeFalsy();
+
+    rerender(
+      genTrigger({
+        popupMotion: { motionName: 'bamboo' },
+      }),
+    );
+    expect(document.querySelector('.bamboo')).toBeTruthy();
+  });
 });


### PR DESCRIPTION
CSSMotion 有一个特性是 `motionName` 在提供后才会开启动画能力。在 antd 中的 Menu 的 `motionName` 正好是异步给的，导致 test 中 snapshot 异常：

<img width="751" height="166" alt="截屏2025-07-28 15 22 23" src="https://github.com/user-attachments/assets/3446257a-2243-4fb7-88d9-3d886248228e" />
