### PR TITLE
fix: no warning

### DIFF
--- a/src/hooks/useWinClick.ts
+++ b/src/hooks/useWinClick.ts
@@ -53,8 +53,8 @@ export default function useWinClick(
       }
 
       // Warning if target and popup not in same root
-      if (process.env.NODE_ENV !== 'production') {
-        const targetRoot = targetEle?.getRootNode?.();
+      if (process.env.NODE_ENV !== 'production' && targetEle) {
+        const targetRoot = targetEle.getRootNode?.();
         const popupRoot = popupEle.getRootNode?.();
 
         warning(


### PR DESCRIPTION
在 #528 中，剥离了 `isMobile` 检测降低 bundle size，使用更通用的方式进行自动切换。这使得在 hoverToClose 中也会添加一个 touchToClose 逻辑，从而走 shadowRoot 的检测。

在 React 18 中，setState 后会立刻触发 useEffect。而在 19 则会合并触发。这使得 targetElement 在 React 18 中会有一个额外的 useEffect warning 检测，导致 warning。然后在下一个 effect update 便跟上 targetElement，是一个无效 warning。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复了在获取目标元素根节点时的判断条件，避免因未定义的目标元素导致的潜在错误。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->