### PR TITLE
fix: the repeated calling of multi-level Trigger triggerOpen method

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -568,7 +568,7 @@ export function generateTrigger(
     const hoverToHide = hideActions.has('hover');
 
     let onPopupMouseEnter: React.MouseEventHandler<HTMLDivElement>;
-    let onPopupMouseLeave: React.MouseEventHandler<HTMLDivElement>;
+    let onPopupMouseLeave: VoidFunction;
 
     const ignoreMouseTrigger = () => {
       return touchedRef.current;


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues
fix https://github.com/ant-design/ant-design/issues/54496

### 💡 Background and Solution
Quickly moving the mouse in and out of menu items triggers the bug
When the mouse leaves the submenu, it triggers onPopupMouseLeave of the previous parent menu, causing the previous parent menu to close unexpectedly

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix dropdown menu display issues caused by rapid mouse movement between menu items |
| 🇨🇳 Chinese | 修复鼠标快速移动进出 dropdown menu 导致 menu 显示异常 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 优化了鼠标移入/移出弹窗的展示与关闭逻辑：进入触发区域或弹窗时会取消待执行的关闭，避免快速移入移出导致意外关闭，重入/重开行为更顺滑、响应更准确。
  * 无对外接口或声明的变更。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->