### PR TITLE
fix: unique popup missing className

### DIFF
--- a/src/UniqueProvider/index.tsx
+++ b/src/UniqueProvider/index.tsx
@@ -15,6 +15,7 @@ import { isDOM } from '@rc-component/util/lib/Dom/findDOMNode';
 import FloatBg from './FloatBg';
 import classNames from 'classnames';
 import MotionContent from './MotionContent';
+import { getAlignPopupClassName } from '../util';
 
 export interface UniqueProviderProps {
   children: React.ReactNode;
@@ -93,6 +94,26 @@ const UniqueProvider = ({ children }: UniqueProviderProps) => {
     false, // isMobile
   );
 
+  const alignedClassName = React.useMemo(() => {
+    if (!options) {
+      return '';
+    }
+
+    const baseClassName = getAlignPopupClassName(
+      options.builtinPlacements || {},
+      options.prefixCls || '',
+      alignInfo,
+      false, // alignPoint is false for UniqueProvider
+    );
+
+    return classNames(baseClassName, options.getPopupClassNameFromAlign?.(alignInfo));
+  }, [
+    alignInfo,
+    options?.getPopupClassNameFromAlign,
+    options?.builtinPlacements,
+    options?.prefixCls,
+  ]);
+
   const contextValue = React.useMemo<UniqueContextProps>(
     () => ({
       show,
@@ -141,6 +162,7 @@ const UniqueProvider = ({ children }: UniqueProviderProps) => {
             }
             className={classNames(
               options.popupClassName,
+              alignedClassName,
               `${prefixCls}-unique-controlled`,
             )}
             style={options.popupStyle}

--- a/src/context.ts
+++ b/src/context.ts
@@ -31,6 +31,7 @@ export interface UniqueShowOptions {
   maskMotion?: CSSMotionProps;
   arrow?: ArrowTypeOuter;
   getPopupContainer?: TriggerProps['getPopupContainer'];
+  getPopupClassNameFromAlign?: (align: AlignType) => string;
 }
 
 export interface UniqueContextProps {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -331,6 +331,7 @@ export function generateTrigger(
       maskMotion,
       arrow: innerArrow,
       getPopupContainer,
+      getPopupClassNameFromAlign,
       id,
     }));
 

--- a/tests/unique.test.tsx
+++ b/tests/unique.test.tsx
@@ -103,4 +103,56 @@ describe('Trigger.Unique', () => {
     // FloatBg open prop should not have changed during transition (no close animation)
     expect(global.openChangeLog).toHaveLength(0);
   });
+
+  it('should add aligned className to UniqueProvider popup', async () => {
+    const getPopupClassNameFromAlign = (align: any) => {
+      return `custom-align-${align.points?.[0] || 'default'}`;
+    };
+
+    const { container } = render(
+      <UniqueProvider>
+        <Trigger
+          action={['click']}
+          popup={<strong className="x-content">tooltip</strong>}
+          unique
+          popupPlacement="bottomLeft"
+          builtinPlacements={{
+            bottomLeft: {
+              points: ['tl', 'bl'],
+              offset: [0, 4],
+              overflow: {
+                adjustX: 0,
+                adjustY: 1,
+              },
+            },
+          }}
+          getPopupClassNameFromAlign={getPopupClassNameFromAlign}
+        >
+          <div className="target">click me</div>
+        </Trigger>
+      </UniqueProvider>,
+    );
+
+    // Initially no popup should be visible
+    expect(document.querySelector('.rc-trigger-popup')).toBeFalsy();
+
+    // Click trigger to show popup
+    fireEvent.click(container.querySelector('.target'));
+    await awaitFakeTimer();
+
+    // Wait a bit more for alignment to complete
+    await awaitFakeTimer();
+
+    // Check that popup exists
+    const popup = document.querySelector('.rc-trigger-popup');
+    expect(popup).toBeTruthy();
+    expect(popup.querySelector('.x-content').textContent).toBe('tooltip');
+
+    // Check that custom className from getPopupClassNameFromAlign is applied
+    expect(popup.className).toContain('custom-align');
+    expect(popup.className).toContain('rc-trigger-popup-unique-controlled');
+
+    // The base placement className might not be available immediately due to async alignment
+    // but the custom className should always be applied
+  });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - 支持通过 getPopupClassNameFromAlign 基于对齐结果动态添加弹层 className，便于按方位定制样式；同时合并内置对齐类与自定义类，渲染更一致。
- 测试
  - 新增用例覆盖对齐派生 className 的应用与可见性，确保弹层内容与样式正确。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->