### PR TITLE
fix: preserve numeric shift inset after popup shift

### DIFF
--- a/src/hooks/useAlign.ts
+++ b/src/hooks/useAlign.ts
@@ -661,6 +661,30 @@ export default function useAlign(
         }
       }
 
+      syncNextPopupPosition();
+
+      if (typeof numShiftX === 'number' && numShiftX !== 0) {
+          const minLeft = visibleRegion.left + numShiftX;
+          const maxRight = visibleRegion.right - numShiftX;
+
+        if (nextPopupX < minLeft) {
+          nextOffsetX += minLeft - nextPopupX;
+        } else if (nextPopupRight > maxRight) {
+          nextOffsetX += maxRight - nextPopupRight;
+        }
+      }
+
+      if (typeof numShiftY === 'number' && numShiftY !== 0) {
+          const minTop = visibleRegion.top + numShiftY;
+          const maxBottom = visibleRegion.bottom - numShiftY;
+
+        if (nextPopupY < minTop) {
+          nextOffsetY += minTop - nextPopupY;
+        } else if (nextPopupBottom > maxBottom) {
+          nextOffsetY += maxBottom - nextPopupBottom;
+        }
+      }
+
       // ============================ Arrow ============================
       // Arrow center align
       const popupLeft = popupRect.x + nextOffsetX;

--- a/tests/flipShift.test.tsx
+++ b/tests/flipShift.test.tsx
@@ -55,6 +55,12 @@ const builtinPlacements = {
     },
     htmlRegion: 'visibleFirst' as const,
   },
+  topShiftInset: {
+    points: ['bc', 'tc'],
+    overflow: {
+      shiftX: 20,
+    },
+  },
   bottom: {
     points: ['tc', 'bc'],
     overflow: {
@@ -192,6 +198,30 @@ describe('Trigger.Flip+Shift', () => {
     // Just need check left < 0
     expect(document.querySelector('.rc-trigger-popup')).toHaveStyle({
       left: '-900px',
+    });
+  });
+
+  it('keeps numeric shiftX as viewport inset after shift', async () => {
+    spanRect.x = -50;
+    spanRect.left = -50;
+
+    render(
+      <Trigger
+        popupVisible
+        popupPlacement="topShiftInset"
+        builtinPlacements={builtinPlacements}
+        popup={<strong>trigger</strong>}
+      >
+        <span className="target" />
+      </Trigger>,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(document.querySelector('.rc-trigger-popup')).toHaveStyle({
+      left: '20px',
     });
   });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 弹出层现在会自动保持在可见区域内，防止边界溢出

* **Tests**
  * 增加测试覆盖以验证弹出层边界约束功能

<!-- end of auto-generated comment: release notes by coderabbit.ai -->