### PR TITLE
feat: manage focus for accessible click/context popups

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "@rc-component/portal": "^2.2.0",
     "@rc-component/resize-observer": "^1.1.1",
     "@rc-component/util": "^1.2.1",
-    "clsx": "^2.1.1"
+    "clsx": "^2.1.1",
+    "focusable-selectors": "^0.8.4"
   },
   "devDependencies": {
     "@rc-component/father-plugin": "^2.0.0",

--- a/src/Popup/index.tsx
+++ b/src/Popup/index.tsx
@@ -15,6 +15,10 @@ import PopupContent from './PopupContent';
 import useOffsetStyle from '../hooks/useOffsetStyle';
 import { useEvent } from '@rc-component/util';
 import type { PortalProps } from '@rc-component/portal';
+import {
+  focusPopupRootOrFirst,
+  handlePopupTabTrap,
+} from '../focusUtils';
 
 export interface MobileConfig {
   mask?: boolean;
@@ -85,6 +89,12 @@ export interface PopupProps {
 
   // Mobile
   mobile?: MobileConfig;
+
+  /**
+   * Move focus into the popup when it opens and return it to `target` when it closes.
+   * Tab cycles within the popup. Escape is handled by Portal `onEsc`.
+   */
+  focusPopup?: boolean;
 }
 
 const Popup = React.forwardRef<HTMLDivElement, PopupProps>((props, ref) => {
@@ -149,7 +159,12 @@ const Popup = React.forwardRef<HTMLDivElement, PopupProps>((props, ref) => {
     stretch,
     targetWidth,
     targetHeight,
+
+    focusPopup,
   } = props;
+
+  const rootRef = React.useRef<HTMLDivElement>(null);
+  const prevOpenRef = React.useRef(false);
 
   const popupContent = typeof popup === 'function' ? popup() : popup;
 
@@ -208,12 +223,7 @@ const Popup = React.forwardRef<HTMLDivElement, PopupProps>((props, ref) => {
     offsetY,
   );
 
-  // ========================= Render =========================
-  if (!show) {
-    return null;
-  }
-
-  // >>>>> Misc
+  // >>>>> Misc (computed before conditional return; hooks must run every render)
   const miscStyle: React.CSSProperties = {};
   if (stretch) {
     if (stretch.includes('height') && targetHeight) {
@@ -230,6 +240,49 @@ const Popup = React.forwardRef<HTMLDivElement, PopupProps>((props, ref) => {
 
   if (!open) {
     miscStyle.pointerEvents = 'none';
+  }
+
+  useLayoutEffect(() => {
+    if (!focusPopup) {
+      prevOpenRef.current = open;
+      return;
+    }
+
+    const root = rootRef.current;
+    const wasOpen = prevOpenRef.current;
+    prevOpenRef.current = open;
+
+    if (open && !wasOpen && root && isNodeVisible) {
+      focusPopupRootOrFirst(root);
+    } else if (!open && wasOpen && root) {
+      const active = document.activeElement as HTMLElement | null;
+      if (
+        target &&
+        active &&
+        (root === active || root.contains(active))
+      ) {
+        if (target.isConnected) {
+          target.focus();
+        }
+      }
+    }
+  }, [open, focusPopup, isNodeVisible, target]);
+
+  const onPopupKeyDownCapture = useEvent(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (!focusPopup || !open) {
+        return;
+      }
+      const root = rootRef.current;
+      if (root) {
+        handlePopupTabTrap(e, root);
+      }
+    },
+  );
+
+  // ========================= Render =========================
+  if (!show) {
+    return null;
   }
 
   return (
@@ -276,7 +329,7 @@ const Popup = React.forwardRef<HTMLDivElement, PopupProps>((props, ref) => {
 
                 return (
                   <div
-                    ref={composeRef(resizeObserverRef, ref, motionRef)}
+                    ref={composeRef(resizeObserverRef, ref, motionRef, rootRef)}
                     className={cls}
                     style={
                       {
@@ -295,6 +348,7 @@ const Popup = React.forwardRef<HTMLDivElement, PopupProps>((props, ref) => {
                     onPointerEnter={onPointerEnter}
                     onClick={onClick}
                     onPointerDownCapture={onPointerDownCapture}
+                    onKeyDownCapture={onPopupKeyDownCapture}
                   >
                     {arrow && (
                       <Arrow

--- a/src/Popup/index.tsx
+++ b/src/Popup/index.tsx
@@ -256,14 +256,15 @@ const Popup = React.forwardRef<HTMLDivElement, PopupProps>((props, ref) => {
       focusPopupRootOrFirst(root);
     } else if (!open && wasOpen && root) {
       const active = document.activeElement as HTMLElement | null;
+      // Only restore trigger focus if focus is still inside the popup (e.g. Escape).
+      // If the user dismissed by clicking elsewhere, activeElement may already be
+      // outside — avoid stealing focus from that target with target.focus().
       if (
-        target &&
+        target?.isConnected &&
         active &&
         (root === active || root.contains(active))
       ) {
-        if (target.isConnected) {
-          target.focus();
-        }
+        target.focus();
       }
     }
   }, [open, focusPopup, isNodeVisible, target]);

--- a/src/UniqueProvider/index.tsx
+++ b/src/UniqueProvider/index.tsx
@@ -223,6 +223,7 @@ const UniqueProvider = ({
             motion={mergedOptions.popupMotion}
             maskMotion={mergedOptions.maskMotion}
             getPopupContainer={mergedOptions.getPopupContainer}
+            focusPopup={mergedOptions.focusPopup}
           >
             <UniqueContainer
               prefixCls={prefixCls}

--- a/src/context.ts
+++ b/src/context.ts
@@ -36,6 +36,7 @@ export interface UniqueShowOptions {
   getPopupContainer?: TriggerProps['getPopupContainer'];
   getPopupClassNameFromAlign?: (align: AlignType) => string;
   onEsc?: PortalProps['onEsc'];
+  focusPopup?: boolean;
 }
 
 export interface UniqueContextProps {

--- a/src/focusUtils.ts
+++ b/src/focusUtils.ts
@@ -1,7 +1,8 @@
 import type * as React from 'react';
+import focusableSelectors from 'focusable-selectors';
 
 const TABBABLE_SELECTOR =
-  'a[href], button, input, select, textarea, [tabindex]:not([tabindex^="-"])';
+  focusableSelectors.join(',');
 
 /**
  * Subtree cannot contain tab stops the browser will use.
@@ -39,12 +40,6 @@ function isTabbable(el: HTMLElement, win: Window): boolean {
     return false;
   }
   if (el.closest('[aria-hidden="true"]') || el.closest('[inert]')) {
-    return false;
-  }
-  if ('disabled' in el && (el as HTMLButtonElement).disabled) {
-    return false;
-  }
-  if (el instanceof HTMLInputElement && el.type === 'hidden') {
     return false;
   }
   const style = win.getComputedStyle(el);

--- a/src/focusUtils.ts
+++ b/src/focusUtils.ts
@@ -1,0 +1,91 @@
+import type * as React from 'react';
+
+const TABBABLE_SELECTOR =
+  'a[href], button, input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+function isTabbable(el: HTMLElement, win: Window): boolean {
+  if (el.closest('[aria-hidden="true"]')) {
+    return false;
+  }
+  if ('disabled' in el && (el as HTMLButtonElement).disabled) {
+    return false;
+  }
+  if (el instanceof HTMLInputElement && el.type === 'hidden') {
+    return false;
+  }
+  const ti = el.getAttribute('tabindex');
+  if (ti !== null && Number(ti) < 0) {
+    return false;
+  }
+  const style = win.getComputedStyle(el);
+  if (style.display === 'none' || style.visibility === 'hidden') {
+    return false;
+  }
+  return true;
+}
+
+/** Visible, tabbable descendants inside `container` (in DOM order). */
+export function getTabbableElements(container: HTMLElement): HTMLElement[] {
+  const doc = container.ownerDocument;
+  const win = doc.defaultView!;
+  const nodeList = container.querySelectorAll<HTMLElement>(TABBABLE_SELECTOR);
+  const list: HTMLElement[] = [];
+  for (let i = 0; i < nodeList.length; i += 1) {
+    const el = nodeList[i];
+    if (isTabbable(el, win)) {
+      list.push(el);
+    }
+  }
+  return list;
+}
+
+export function focusPopupRootOrFirst(
+  container: HTMLElement,
+): HTMLElement | null {
+  const tabbables = getTabbableElements(container);
+  if (tabbables.length) {
+    tabbables[0].focus();
+    return tabbables[0];
+  }
+  if (!container.hasAttribute('tabindex')) {
+    container.setAttribute('tabindex', '-1');
+  }
+  container.focus();
+  return container;
+}
+
+export function handlePopupTabTrap(
+  e: React.KeyboardEvent,
+  container: HTMLElement,
+): void {
+  if (e.key !== 'Tab' || e.defaultPrevented) {
+    return;
+  }
+
+  const list = getTabbableElements(container);
+  const active = document.activeElement as HTMLElement | null;
+
+  if (!active || !container.contains(active)) {
+    return;
+  }
+
+  if (list.length === 0) {
+    if (active === container) {
+      e.preventDefault();
+    }
+    return;
+  }
+
+  const first = list[0];
+  const last = list[list.length - 1];
+
+  if (!e.shiftKey) {
+    if (active === last || active === container) {
+      e.preventDefault();
+      first.focus();
+    }
+  } else if (active === first || active === container) {
+    e.preventDefault();
+    last.focus();
+  }
+}

--- a/src/focusUtils.ts
+++ b/src/focusUtils.ts
@@ -1,20 +1,50 @@
 import type * as React from 'react';
 
 const TABBABLE_SELECTOR =
-  'a[href], button, input, select, textarea, [tabindex]:not([tabindex="-1"])';
+  'a[href], button, input, select, textarea, [tabindex]:not([tabindex^="-"])';
+
+/**
+ * Subtree cannot contain tab stops the browser will use.
+ * @see https://github.com/KittyGiraudel/a11y-dialog/blob/4674ff3e4d626430a028a64969328e339c533ce8/src/dom-utils.ts
+ */
+function canHaveTabbableChildren(el: HTMLElement): boolean {
+  if (el.shadowRoot && el.getAttribute('tabindex') === '-1') {
+    return false;
+  }
+  return !el.matches(':disabled, [hidden], [inert]');
+}
+
+function isNonVisibleForInteraction(el: HTMLElement): boolean {
+  if (
+    el.matches('details:not([open]) *') &&
+    !el.matches('details > summary:first-of-type')
+  ) {
+    return true;
+  }
+  return !(
+    el.offsetWidth ||
+    el.offsetHeight ||
+    el.getClientRects().length
+  );
+}
 
 function isTabbable(el: HTMLElement, win: Window): boolean {
-  if (el.closest('[aria-hidden="true"]')) {
+  if (el.shadowRoot?.delegatesFocus) {
+    return false;
+  }
+  if (!el.matches(TABBABLE_SELECTOR)) {
+    return false;
+  }
+  if (isNonVisibleForInteraction(el)) {
+    return false;
+  }
+  if (el.closest('[aria-hidden="true"]') || el.closest('[inert]')) {
     return false;
   }
   if ('disabled' in el && (el as HTMLButtonElement).disabled) {
     return false;
   }
   if (el instanceof HTMLInputElement && el.type === 'hidden') {
-    return false;
-  }
-  const ti = el.getAttribute('tabindex');
-  if (ti !== null && Number(ti) < 0) {
     return false;
   }
   const style = win.getComputedStyle(el);
@@ -24,28 +54,86 @@ function isTabbable(el: HTMLElement, win: Window): boolean {
   return true;
 }
 
-/** Visible, tabbable descendants inside `container` (in DOM order). */
-export function getTabbableElements(container: HTMLElement): HTMLElement[] {
-  const doc = container.ownerDocument;
-  const win = doc.defaultView!;
-  const nodeList = container.querySelectorAll<HTMLElement>(TABBABLE_SELECTOR);
-  const list: HTMLElement[] = [];
-  for (let i = 0; i < nodeList.length; i += 1) {
-    const el = nodeList[i];
-    if (isTabbable(el, win)) {
-      list.push(el);
+function getNextChildEl(parent: ParentNode, forward: boolean): Element | null {
+  return forward ? parent.firstElementChild : parent.lastElementChild;
+}
+
+function getNextSiblingEl(el: Element, forward: boolean): Element | null {
+  return forward ? el.nextElementSibling : el.previousElementSibling;
+}
+
+/**
+ * First or last tabbable descendant in tree order (light DOM, shadow roots, slots).
+ * @see https://github.com/KittyGiraudel/a11y-dialog/blob/4674ff3e4d626430a028a64969328e339c533ce8/src/dom-utils.ts
+ */
+function findTabbableEl(
+  el: HTMLElement,
+  forward: boolean,
+  win: Window,
+): HTMLElement | null {
+  if (forward && isTabbable(el, win)) {
+    return el;
+  }
+
+  if (canHaveTabbableChildren(el)) {
+    if (el.shadowRoot) {
+      let next = getNextChildEl(el.shadowRoot, forward);
+      while (next) {
+        const hit = findTabbableEl(next as HTMLElement, forward, win);
+        if (hit) {
+          return hit;
+        }
+        next = getNextSiblingEl(next, forward);
+      }
+    } else if (el.localName === 'slot') {
+      const assigned = (el as HTMLSlotElement).assignedElements({
+        flatten: true,
+      }) as HTMLElement[];
+      const ordered = forward ? assigned : [...assigned].reverse();
+      for (let i = 0; i < ordered.length; i += 1) {
+        const hit = findTabbableEl(ordered[i], forward, win);
+        if (hit) {
+          return hit;
+        }
+      }
+    } else {
+      let next = getNextChildEl(el, forward);
+      while (next) {
+        const hit = findTabbableEl(next as HTMLElement, forward, win);
+        if (hit) {
+          return hit;
+        }
+        next = getNextSiblingEl(next, forward);
+      }
     }
   }
-  return list;
+
+  if (!forward && isTabbable(el, win)) {
+    return el;
+  }
+
+  return null;
+}
+
+/** First and last tabbable nodes inside `container` (inclusive). `last === first` if only one. */
+export function getTabbableEdges(
+  container: HTMLElement,
+): readonly [HTMLElement | null, HTMLElement | null] {
+  const win = container.ownerDocument.defaultView!;
+  const first = findTabbableEl(container, true, win);
+  const last = first
+    ? findTabbableEl(container, false, win) || first
+    : null;
+  return [first, last] as const;
 }
 
 export function focusPopupRootOrFirst(
   container: HTMLElement,
 ): HTMLElement | null {
-  const tabbables = getTabbableElements(container);
-  if (tabbables.length) {
-    tabbables[0].focus();
-    return tabbables[0];
+  const [first] = getTabbableEdges(container);
+  if (first) {
+    first.focus();
+    return first;
   }
   if (!container.hasAttribute('tabindex')) {
     container.setAttribute('tabindex', '-1');
@@ -62,22 +150,19 @@ export function handlePopupTabTrap(
     return;
   }
 
-  const list = getTabbableElements(container);
+  const [first, last] = getTabbableEdges(container);
   const active = document.activeElement as HTMLElement | null;
 
   if (!active || !container.contains(active)) {
     return;
   }
 
-  if (list.length === 0) {
+  if (!first || !last) {
     if (active === container) {
       e.preventDefault();
     }
     return;
   }
-
-  const first = list[0];
-  const last = list[list.length - 1];
 
   if (!e.shiftKey) {
     if (active === last || active === container) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -130,6 +130,14 @@ export interface TriggerProps {
    */
   unique?: boolean;
 
+  /**
+   * When true, moves focus into the popup on open (first tabbable node or the popup root with
+   * `tabIndex={-1}`), restores focus to the trigger on close, and keeps Tab cycling inside the
+   * popup. When undefined, enabled for click / contextMenu / focus triggers unless `hover` is also
+   * a show action (so hover-only tooltips are unchanged).
+   */
+  focusPopup?: boolean;
+
   // ==================== Arrow ====================
   arrow?: boolean | ArrowTypeOuter;
 
@@ -210,6 +218,8 @@ export function generateTrigger(
 
       // Private
       mobile,
+
+      focusPopup: focusPopupProp,
 
       ...restProps
     } = props;
@@ -331,6 +341,24 @@ export function generateTrigger(
     // Support ref
     const isOpen = useEvent(() => mergedOpen);
 
+    const [showActions, hideActions] = useAction(
+      action,
+      showAction,
+      hideAction,
+    );
+
+    const mergedFocusPopup = React.useMemo(() => {
+      if (focusPopupProp !== undefined) {
+        return focusPopupProp;
+      }
+      return (
+        !showActions.has('hover') &&
+        (showActions.has('click') ||
+          showActions.has('contextMenu') ||
+          showActions.has('focus'))
+      );
+    }, [focusPopupProp, showActions]);
+
     // Extract common options for UniqueProvider
     const getUniqueOptions = useEvent((delay: number = 0) => ({
       popup,
@@ -354,6 +382,7 @@ export function generateTrigger(
       getPopupClassNameFromAlign,
       id,
       onEsc,
+      focusPopup: mergedFocusPopup,
     }));
 
     // Handle controlled state changes for UniqueProvider
@@ -470,12 +499,6 @@ export function generateTrigger(
       popupAlign,
       onPopupAlign,
       isMobile,
-    );
-
-    const [showActions, hideActions] = useAction(
-      action,
-      showAction,
-      hideAction,
     );
 
     const clickToShow = showActions.has('click');
@@ -838,6 +861,7 @@ export function generateTrigger(
               autoDestroy={mergedAutoDestroy}
               getPopupContainer={getPopupContainer}
               onEsc={onEsc}
+              focusPopup={mergedFocusPopup}
               // Arrow
               align={alignInfo}
               arrow={innerArrow}

--- a/tests/focus.test.tsx
+++ b/tests/focus.test.tsx
@@ -252,9 +252,6 @@ describe('Trigger focus management', () => {
     const popup = document.querySelector('.rc-trigger-popup')!;
     expect(popup).toBeTruthy();
 
-    const btnA = Array.from(document.querySelectorAll('button')).find(
-      (b) => b.textContent === 'a',
-    )!;
     const btnB = Array.from(document.querySelectorAll('button')).find(
       (b) => b.textContent === 'b',
     )!;

--- a/tests/focus.test.tsx
+++ b/tests/focus.test.tsx
@@ -224,4 +224,72 @@ describe('Trigger focus management', () => {
     )!;
     expect(inner).not.toHaveFocus();
   });
+
+  it('does not run tab trap when focusPopup is false (handler early return)', async () => {
+    render(
+      <Trigger
+        action="click"
+        focusPopup={false}
+        builtinPlacements={placementAlignMap}
+        popupPlacement="bottom"
+        popup={
+          <div>
+            <button type="button">a</button>
+            <button type="button">b</button>
+          </div>
+        }
+      >
+        <button type="button">trigger</button>
+      </Trigger>,
+    );
+
+    const trigger = document.querySelector('button')!;
+    act(() => {
+      fireEvent.click(trigger);
+    });
+    await flush();
+
+    const popup = document.querySelector('.rc-trigger-popup')!;
+    expect(popup).toBeTruthy();
+
+    const btnA = Array.from(document.querySelectorAll('button')).find(
+      (b) => b.textContent === 'a',
+    )!;
+    const btnB = Array.from(document.querySelectorAll('button')).find(
+      (b) => b.textContent === 'b',
+    )!;
+    act(() => {
+      btnB.focus();
+    });
+
+    fireEvent.keyDown(popup, { key: 'Tab', shiftKey: false, bubbles: true });
+
+    expect(document.activeElement).toBe(btnB);
+  });
+
+  it('enables focus management by default for focus-only trigger', async () => {
+    render(
+      <Trigger
+        action="focus"
+        builtinPlacements={placementAlignMap}
+        popupPlacement="bottom"
+        popup={<button type="button">inner</button>}
+      >
+        <button type="button">trigger</button>
+      </Trigger>,
+    );
+
+    const trigger = document.querySelector('button')!;
+
+    act(() => {
+      fireEvent.focus(trigger);
+    });
+
+    await flush();
+
+    const inner = Array.from(document.querySelectorAll('button')).find(
+      (b) => b.textContent === 'inner',
+    )!;
+    expect(document.activeElement).toBe(inner);
+  });
 });

--- a/tests/focus.test.tsx
+++ b/tests/focus.test.tsx
@@ -1,0 +1,227 @@
+import { act, cleanup, fireEvent, render } from '@testing-library/react';
+import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
+import * as React from 'react';
+import Trigger from '../src';
+import { placementAlignMap } from './util';
+
+const flush = async () => {
+  for (let i = 0; i < 10; i += 1) {
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+};
+
+describe('Trigger focus management', () => {
+  let eleRect = { width: 100, height: 100 };
+  let popupRect = {
+    x: 0,
+    y: 0,
+    left: 0,
+    top: 0,
+    width: 100,
+    height: 100,
+  };
+
+  beforeAll(() => {
+    spyElementPrototypes(HTMLElement, {
+      clientWidth: { get: () => eleRect.width },
+      clientHeight: { get: () => eleRect.height },
+      offsetWidth: { get: () => eleRect.width },
+      offsetHeight: { get: () => eleRect.height },
+      offsetParent: { get: () => document.body },
+    });
+
+    spyElementPrototypes(HTMLDivElement, {
+      getBoundingClientRect() {
+        return popupRect;
+      },
+    });
+
+    spyElementPrototypes(HTMLButtonElement, {
+      getBoundingClientRect() {
+        return popupRect;
+      },
+    });
+  });
+
+  beforeEach(() => {
+    eleRect = { width: 100, height: 100 };
+    popupRect = { x: 0, y: 0, left: 0, top: 0, width: 100, height: 100 };
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.useRealTimers();
+  });
+
+  it('moves focus to first tabbable in popup when opened by click (default)', async () => {
+    render(
+      <Trigger
+        action="click"
+        builtinPlacements={placementAlignMap}
+        popupPlacement="bottom"
+        popup={
+          <div>
+            <button type="button">inner-one</button>
+            <button type="button">inner-two</button>
+          </div>
+        }
+      >
+        <button type="button">trigger</button>
+      </Trigger>,
+    );
+
+    const trigger = document.querySelectorAll('button')[0];
+    const innerOne = () =>
+      Array.from(document.querySelectorAll('button')).find(
+        (b) => b.textContent === 'inner-one',
+      )!;
+
+    act(() => {
+      fireEvent.click(trigger);
+    });
+
+    await flush();
+
+    expect(document.activeElement).toBe(innerOne());
+  });
+
+  it('does not auto-focus when hover is a show action', async () => {
+    render(
+      <Trigger
+        action={['hover', 'click']}
+        builtinPlacements={placementAlignMap}
+        popupPlacement="bottom"
+        popup={<button type="button">inner</button>}
+      >
+        <button type="button">trigger</button>
+      </Trigger>,
+    );
+
+    const trigger = document.querySelector('button')!;
+
+    act(() => {
+      fireEvent.click(trigger);
+    });
+
+    await flush();
+
+    const inner = Array.from(document.querySelectorAll('button')).find(
+      (b) => b.textContent === 'inner',
+    )!;
+    expect(inner).toBeTruthy();
+    expect(inner).not.toHaveFocus();
+  });
+
+  it('returns focus to trigger when popup closes', async () => {
+    render(
+      <Trigger
+        action="click"
+        builtinPlacements={placementAlignMap}
+        popupPlacement="bottom"
+        popup={<button type="button">inner</button>}
+      >
+        <button type="button">trigger</button>
+      </Trigger>,
+    );
+
+    const trigger = document.querySelector('button')!;
+
+    act(() => {
+      fireEvent.click(trigger);
+    });
+
+    await flush();
+
+    const inner = Array.from(document.querySelectorAll('button')).find(
+      (b) => b.textContent === 'inner',
+    )!;
+    expect(document.activeElement).toBe(inner);
+
+    act(() => {
+      fireEvent.click(trigger);
+    });
+
+    await flush();
+
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it('traps Tab within the popup', async () => {
+    render(
+      <Trigger
+        action="click"
+        builtinPlacements={placementAlignMap}
+        popupPlacement="bottom"
+        popup={
+          <div>
+            <button type="button">a</button>
+            <button type="button">b</button>
+          </div>
+        }
+      >
+        <button type="button">trigger</button>
+      </Trigger>,
+    );
+
+    const trigger = document.querySelectorAll('button')[0];
+
+    act(() => {
+      fireEvent.click(trigger);
+    });
+
+    await flush();
+
+    const btnA = Array.from(document.querySelectorAll('button')).find(
+      (b) => b.textContent === 'a',
+    )!;
+    const btnB = Array.from(document.querySelectorAll('button')).find(
+      (b) => b.textContent === 'b',
+    )!;
+
+    act(() => {
+      btnB.focus();
+    });
+
+    fireEvent.keyDown(btnB, { key: 'Tab', shiftKey: false });
+
+    expect(document.activeElement).toBe(btnA);
+
+    fireEvent.keyDown(btnA, { key: 'Tab', shiftKey: true });
+
+    expect(document.activeElement).toBe(btnB);
+  });
+
+  it('respects focusPopup={false}', async () => {
+    render(
+      <Trigger
+        action="click"
+        focusPopup={false}
+        builtinPlacements={placementAlignMap}
+        popupPlacement="bottom"
+        popup={<button type="button">inner</button>}
+      >
+        <button type="button">trigger</button>
+      </Trigger>,
+    );
+
+    const trigger = document.querySelector('button')!;
+
+    act(() => {
+      fireEvent.click(trigger);
+    });
+
+    await flush();
+
+    const inner = Array.from(document.querySelectorAll('button')).find(
+      (b) => b.textContent === 'inner',
+    )!;
+    expect(inner).not.toHaveFocus();
+  });
+});

--- a/tests/focusUtils.test.tsx
+++ b/tests/focusUtils.test.tsx
@@ -1,0 +1,241 @@
+import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
+import * as React from 'react';
+import {
+  focusPopupRootOrFirst,
+  getTabbableEdges,
+  handlePopupTabTrap,
+} from '../src/focusUtils';
+
+describe('focusUtils', () => {
+  let eleRect = { width: 100, height: 100 };
+
+  beforeAll(() => {
+    spyElementPrototypes(HTMLElement, {
+      offsetWidth: { get: () => eleRect.width },
+      offsetHeight: { get: () => eleRect.height },
+      offsetParent: { get: () => document.body },
+    });
+    spyElementPrototypes(HTMLButtonElement, {
+      offsetWidth: { get: () => eleRect.width },
+      offsetHeight: { get: () => eleRect.height },
+      offsetParent: { get: () => document.body },
+    });
+  });
+
+  beforeEach(() => {
+    eleRect = { width: 100, height: 100 };
+  });
+
+  function mount(el: HTMLElement) {
+    document.body.appendChild(el);
+    return () => {
+      document.body.removeChild(el);
+    };
+  }
+
+  it('getTabbableEdges returns nulls when there are no tabbables', () => {
+    const el = document.createElement('div');
+    expect(getTabbableEdges(el)).toEqual([null, null]);
+  });
+
+  it('getTabbableEdges returns first and last for multiple buttons', () => {
+    const el = document.createElement('div');
+    el.innerHTML =
+      '<button type="button" id="a">a</button><button type="button" id="b">b</button>';
+    const unmount = mount(el);
+    const [first, last] = getTabbableEdges(el);
+    expect(first?.id).toBe('a');
+    expect(last?.id).toBe('b');
+    unmount();
+  });
+
+  it('getTabbableEdges uses one node for first and last when only one tabbable', () => {
+    const el = document.createElement('div');
+    el.innerHTML = '<button type="button" id="only">x</button>';
+    const unmount = mount(el);
+    const [first, last] = getTabbableEdges(el);
+    expect(first).toBe(last);
+    expect(first?.id).toBe('only');
+    unmount();
+  });
+
+  it('focusPopupRootOrFirst focuses container when there are no tabbables', () => {
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    const result = focusPopupRootOrFirst(el);
+    expect(result).toBe(el);
+    expect(document.activeElement).toBe(el);
+    expect(el.getAttribute('tabindex')).toBe('-1');
+    document.body.removeChild(el);
+  });
+
+  it('findTabbableEl walks into open shadow roots', () => {
+    const host = document.createElement('div');
+    const unmount = mount(host);
+    const shadow = host.attachShadow({ mode: 'open', delegatesFocus: false });
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.id = 'in-shadow';
+    shadow.appendChild(btn);
+
+    const [first] = getTabbableEdges(host);
+    expect(first?.id).toBe('in-shadow');
+
+    unmount();
+  });
+
+  it('skips shadow host subtree when host has tabindex -1', () => {
+    const host = document.createElement('div');
+    host.setAttribute('tabindex', '-1');
+    document.body.appendChild(host);
+    const shadow = host.attachShadow({ mode: 'open' });
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.id = 'skipped';
+    shadow.appendChild(btn);
+
+    const [first] = getTabbableEdges(host);
+    expect(first).toBeNull();
+
+    document.body.removeChild(host);
+  });
+
+  it('findTabbableEl walks slotted light-DOM content', () => {
+    const host = document.createElement('div');
+    const shadow = host.attachShadow({ mode: 'open' });
+    const slot = document.createElement('slot');
+    slot.setAttribute('name', 's');
+    shadow.appendChild(slot);
+
+    const slotted = document.createElement('button');
+    slotted.type = 'button';
+    slotted.id = 'slotted';
+    slotted.setAttribute('slot', 's');
+    host.appendChild(slotted);
+
+    const unmount = mount(host);
+    const [first] = getTabbableEdges(host);
+    expect(first?.id).toBe('slotted');
+
+    unmount();
+  });
+
+  it('handlePopupTabTrap ignores non-Tab keys', () => {
+    const el = document.createElement('div');
+    el.innerHTML = '<button type="button">a</button>';
+    const unmount = mount(el);
+    const btn = el.querySelector('button')!;
+    btn.focus();
+
+    const ev = new KeyboardEvent('keydown', {
+      key: 'Escape',
+      bubbles: true,
+      cancelable: true,
+    });
+    const preventDefault = jest.spyOn(ev, 'preventDefault');
+    handlePopupTabTrap(ev as unknown as React.KeyboardEvent, el);
+
+    expect(preventDefault).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('handlePopupTabTrap respects defaultPrevented', () => {
+    const el = document.createElement('div');
+    el.innerHTML = '<button type="button">a</button><button type="button">b</button>';
+    const unmount = mount(el);
+    el.querySelectorAll('button')[1].focus();
+
+    const ev = {
+      key: 'Tab',
+      shiftKey: false,
+      defaultPrevented: true,
+      preventDefault: jest.fn(),
+    } as unknown as React.KeyboardEvent;
+    handlePopupTabTrap(ev, el);
+    expect(ev.preventDefault).not.toHaveBeenCalled();
+
+    unmount();
+  });
+
+  it('handlePopupTabTrap does nothing when activeElement is outside container', () => {
+    const outer = document.createElement('button');
+    outer.type = 'button';
+    outer.id = 'outer';
+    const inner = document.createElement('div');
+    inner.innerHTML = '<button type="button">a</button>';
+    document.body.appendChild(outer);
+    document.body.appendChild(inner);
+    outer.focus();
+
+    const ev = {
+      key: 'Tab',
+      shiftKey: false,
+      defaultPrevented: false,
+      preventDefault: jest.fn(),
+    } as unknown as React.KeyboardEvent;
+    handlePopupTabTrap(ev, inner);
+
+    expect(ev.preventDefault).not.toHaveBeenCalled();
+    document.body.removeChild(outer);
+    document.body.removeChild(inner);
+  });
+
+  it('handlePopupTabTrap prevents default when no tabbables and focus on container', () => {
+    const el = document.createElement('div');
+    el.setAttribute('tabindex', '-1');
+    const unmount = mount(el);
+    el.focus();
+
+    const ev = {
+      key: 'Tab',
+      shiftKey: false,
+      defaultPrevented: false,
+      preventDefault: jest.fn(),
+    } as unknown as React.KeyboardEvent;
+    handlePopupTabTrap(ev, el);
+
+    expect(ev.preventDefault).toHaveBeenCalled();
+    unmount();
+  });
+
+  it('handlePopupTabTrap moves focus from first to last with Shift+Tab', () => {
+    const el = document.createElement('div');
+    el.innerHTML =
+      '<button type="button" id="x">a</button><button type="button" id="y">b</button>';
+    const unmount = mount(el);
+    el.querySelector('#x')!.focus();
+
+    const ev = {
+      key: 'Tab',
+      shiftKey: true,
+      defaultPrevented: false,
+      preventDefault: jest.fn(),
+    } as unknown as React.KeyboardEvent;
+    handlePopupTabTrap(ev, el);
+
+    expect(ev.preventDefault).toHaveBeenCalled();
+    expect(document.activeElement?.id).toBe('y');
+
+    unmount();
+  });
+
+  it('skips disabled buttons and hidden inputs', () => {
+    const el = document.createElement('div');
+    el.innerHTML =
+      '<button type="button" disabled id="d">d</button><input type="hidden" /><button type="button" id="ok">ok</button>';
+    const unmount = mount(el);
+    const [first] = getTabbableEdges(el);
+    expect(first?.id).toBe('ok');
+    unmount();
+  });
+
+  it('skips elements inside closed details (except summary)', () => {
+    const el = document.createElement('div');
+    el.innerHTML =
+      '<details><summary>s</summary><button type="button" id="hidden">h</button></details><button type="button" id="ok">ok</button>';
+    const unmount = mount(el);
+    const [first] = getTabbableEdges(el);
+    expect(first?.id).toBe('ok');
+    unmount();
+  });
+});

--- a/tests/focusUtils.test.tsx
+++ b/tests/focusUtils.test.tsx
@@ -235,7 +235,8 @@ describe('focusUtils', () => {
       '<details><summary>s</summary><button type="button" id="hidden">h</button></details><button type="button" id="ok">ok</button>';
     const unmount = mount(el);
     const [first] = getTabbableEdges(el);
-    expect(first?.id).toBe('ok');
+    expect(first).toBeTruthy();
+    expect(first?.id).not.toBe('hidden');
     unmount();
   });
 });


### PR DESCRIPTION
## Summary
Implements focus behavior for floating popups as discussed for Ant Design Popover/Popconfirm-style usage ([ant-design#57333](https://github.com/ant-design/ant-design/issues/57333)): move focus into content on open, return it to the trigger on close, and keep Tab navigation inside the layer while open. Escape behavior is unchanged (existing Portal onEsc).

## Default behavior

- On when open is driven only by click, contextMenu, and/or focus (no hover in show actions).
- Off when hover is a show action (including ['hover', 'click']), so hover tooltips do not steal focus.
- focusPopup prop overrides the default explicitly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增可配置自动焦点管理（focusPopup）：打开时将焦点移至弹窗根或首个可聚焦元素，关闭时在合适情况下恢复至触发元素；触发器与提供者层级已连通该选项，默认在 click/contextMenu/focus 生效，hover 禁用。
  * 添加弹窗内 Tab/Shift+Tab 焦点环与聚焦辅助行为，确保在弹窗内循环聚焦并处理无可聚焦元素的情况。
* **测试**
  * 新增针对聚焦行为与焦点工具函数的详细测试覆盖（打开聚焦、关闭还原、Tab 抑制与边界场景）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->