### PR TITLE
fix(align): restore overflowX and overflowY after force align

### DIFF
--- a/src/hooks/useAlign.ts
+++ b/src/hooks/useAlign.ts
@@ -184,6 +184,9 @@ export default function useAlign(
       const originRight = popupElement.style.right;
       const originBottom = popupElement.style.bottom;
       const originOverflow = popupElement.style.overflow;
+      const originOverflowX = popupElement.style.overflowX;
+      const originOverflowY = popupElement.style.overflowY;
+
 
       // Placement
       const placementInfo: AlignType = {
@@ -295,6 +298,8 @@ export default function useAlign(
       popupElement.style.right = originRight;
       popupElement.style.bottom = originBottom;
       popupElement.style.overflow = originOverflow;
+      popupElement.style.overflowX = originOverflowX;
+      popupElement.style.overflowY = originOverflowY;
 
       popupElement.parentElement?.removeChild(placeholderElement);
 

--- a/tests/align.test.tsx
+++ b/tests/align.test.tsx
@@ -226,6 +226,40 @@ describe('Trigger.Align', () => {
     });
   });
 
+  it('should restore overflowX and overflowY after align', async () => {
+    const triggerRef = React.createRef<TriggerRef>();
+
+    render(
+      <Trigger
+        popupVisible
+        popup={<span className="bamboo" />}
+        popupStyle={{
+          overflowX: 'auto',
+          overflowY: 'scroll',
+        }}
+        ref={triggerRef}
+      >
+        <div />
+      </Trigger>,
+    );
+
+    await awaitFakeTimer();
+
+    const popupElement = document.querySelector(
+      '.rc-trigger-popup',
+    ) as HTMLElement;
+    expect(popupElement.style.overflowX).toBe('auto');
+    expect(popupElement.style.overflowY).toBe('scroll');
+
+    act(() => {
+      triggerRef.current!.forceAlign();
+    });
+    await awaitFakeTimer();
+
+    expect(popupElement.style.overflowX).toBe('auto');
+    expect(popupElement.style.overflowY).toBe('scroll');
+  });
+
   it('targetOffset support ptg', async () => {
     render(
       <Trigger


### PR DESCRIPTION
solve https://github.com/ant-design/ant-design/issues/57665

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 改进弹出窗口对齐过程，确保正确保持和恢复溢出样式设置

* **测试**
  * 添加测试用例，验证对齐过程中溢出样式的保持一致性

<!-- end of auto-generated comment: release notes by coderabbit.ai -->