### PR TITLE
fix: import from @rc-component/util package root

### DIFF
--- a/src/Popup/index.tsx
+++ b/src/Popup/index.tsx
@@ -4,8 +4,7 @@ import CSSMotion from '@rc-component/motion';
 import ResizeObserver, {
   type ResizeObserverProps,
 } from '@rc-component/resize-observer';
-import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
-import { composeRef } from '@rc-component/util/lib/ref';
+import { composeRef, useLayoutEffect } from '@rc-component/util';
 import * as React from 'react';
 import type { TriggerProps } from '../';
 import type { AlignType, ArrowPos, ArrowTypeOuter } from '../interface';

--- a/src/UniqueProvider/index.tsx
+++ b/src/UniqueProvider/index.tsx
@@ -9,9 +9,8 @@ import TriggerContext, {
 import useDelay from '../hooks/useDelay';
 import useAlign from '../hooks/useAlign';
 import Popup from '../Popup';
-import { useEvent } from '@rc-component/util';
+import { isDOM, useEvent } from '@rc-component/util';
 import useTargetState from './useTargetState';
-import { isDOM } from '@rc-component/util/lib/Dom/findDOMNode';
 import UniqueContainer from './UniqueContainer';
 import { clsx } from 'clsx';
 import { getAlignPopupClassName } from '../util';

--- a/src/hooks/useAlign.ts
+++ b/src/hooks/useAlign.ts
@@ -1,7 +1,9 @@
-import { isDOM } from '@rc-component/util/lib/Dom/findDOMNode';
-import isVisible from '@rc-component/util/lib/Dom/isVisible';
-import useEvent from '@rc-component/util/lib/hooks/useEvent';
-import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
+import {
+  isDOM,
+  isVisible,
+  useEvent,
+  useLayoutEffect,
+} from '@rc-component/util';
 import * as React from 'react';
 import type { TriggerProps } from '..';
 import type {

--- a/src/hooks/useWatch.ts
+++ b/src/hooks/useWatch.ts
@@ -1,4 +1,4 @@
-import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
+import { useLayoutEffect } from '@rc-component/util';
 import { collectScroller, getWin } from '../util';
 
 export default function useWatch(

--- a/src/hooks/useWinClick.ts
+++ b/src/hooks/useWinClick.ts
@@ -1,5 +1,4 @@
-import { getShadowRoot } from '@rc-component/util/lib/Dom/shadow';
-import { warning } from '@rc-component/util/lib/warning';
+import { getShadowRoot, warning } from '@rc-component/util';
 import * as React from 'react';
 import { getWin } from '../util';
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,12 +2,16 @@ import Portal from '@rc-component/portal';
 import { clsx } from 'clsx';
 import type { CSSMotionProps } from '@rc-component/motion';
 import { useResizeObserver } from '@rc-component/resize-observer';
-import { getDOM, isDOM } from '@rc-component/util/lib/Dom/findDOMNode';
-import { getShadowRoot } from '@rc-component/util/lib/Dom/shadow';
-import { getNodeRef, useComposeRef } from '@rc-component/util/lib/ref';
-import useEvent from '@rc-component/util/lib/hooks/useEvent';
-import useId from '@rc-component/util/lib/hooks/useId';
-import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
+import {
+  getDOM,
+  getNodeRef,
+  getShadowRoot,
+  isDOM,
+  useComposeRef,
+  useEvent,
+  useId,
+  useLayoutEffect,
+} from '@rc-component/util';
 import * as React from 'react';
 import Popup, { type MobileConfig } from './Popup';
 import type { TriggerContextProps } from './context';


### PR DESCRIPTION
## Summary

`npm run compile` 失败，因为 `father-plugin` 注入的 `no-restricted-imports` lint 规则禁止从 `@rc-component/*/lib/**` 子路径导入，需要改为包根导入。

This PR replaces all 6 `@rc-component/util/lib/*` imports with named imports from the package root.

## Affected files

- `src/Popup/index.tsx`
- `src/UniqueProvider/index.tsx`
- `src/hooks/useAlign.ts`
- `src/hooks/useWatch.ts`
- `src/hooks/useWinClick.ts`
- `src/index.tsx`

## Notes

- `warning` in `useWinClick.ts` switches from the always-fire named `warning` to the package root's default export (which is `warningOnce`). This is dev-only and dedup is preferable for a same-shadow-root sanity check that would otherwise spam on every effect re-run.

## Test plan

- [x] `npm run compile` passes
- [x] `npm test` — 130 passed / 1 pre-existing skip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发版说明

* **代码优化**
  * 调整了内部依赖包的导入方式，优化模块结构

**用户影响：** 此版本无任何用户可见的功能变更，仅涉及内部代码结构调整。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->