### PR TITLE
fix: skip iframe html and body in visible area

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -107,7 +107,7 @@ export function getVisibleArea(
   const visibleArea = { ...initArea };
 
   (scrollerList || []).forEach((ele) => {
-    if (ele instanceof HTMLBodyElement || ele instanceof HTMLHtmlElement) {
+    if (ele.tagName === 'BODY' || ele.tagName === 'HTML') {
       return;
     }
 

--- a/tests/flip.test.tsx
+++ b/tests/flip.test.tsx
@@ -366,6 +366,27 @@ describe('Trigger.Align', () => {
     window.getComputedStyle = oriGetComputedStyle;
   });
 
+  it('skips iframe html and body elements', () => {
+    const initArea = {
+      left: 0,
+      right: 500,
+      top: 0,
+      bottom: 500,
+    };
+    const iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+
+    try {
+      const { documentElement, body } = iframe.contentDocument!;
+
+      expect(getVisibleArea(initArea, [documentElement, body])).toEqual(
+        initArea,
+      );
+    } finally {
+      iframe.remove();
+    }
+  });
+
   // e.g. adjustY + shiftX may make popup out but push back in screen
   // which should keep flip
   /*


### PR DESCRIPTION
Fix https://github.com/react-component/trigger/issues/623.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 修复
* 优化了可见区域计算中对滚动容器根元素的检测方式

## 测试
* 新增 iframe 元素的测试用例，确保框架内的根元素被正确跳过

<!-- end of auto-generated comment: release notes by coderabbit.ai -->