### PR TITLE
feat: support disabled prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Then open `http://localhost:8000`.
 | blurDelay                  | Delay before hiding on blur, in seconds.                                  | `number`                                  | -                  |
 | builtinPlacements          | Named placement presets.                                                  | `BuildInPlacements`                       | `{}`               |
 | defaultPopupVisible        | Initial uncontrolled visibility.                                          | `boolean`                                 | `false`            |
+| disabled                   | Temporarily suppress popup visibility without resetting the current open state. | `boolean`                                 | `false`            |
 | focusDelay                 | Delay before showing on focus, in seconds.                                | `number`                                  | -                  |
 | forceRender                | Render popup before it is first shown.                                    | `boolean`                                 | `false`            |
 | fresh                      | Keep popup content updated while closed.                                  | `boolean`                                 | -                  |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -75,6 +75,7 @@ npm start
 | blurDelay                  | `blur` 后隐藏前的延迟，单位为秒。                                  | `number`                                  | -                  |
 | builtinPlacements          | 命名位置预设。                                                  | `BuildInPlacements`                       | `{}`               |
 | defaultPopupVisible        | 非受控初始显示状态。                                          | `boolean`                                 | `false`            |
+| disabled                   | 临时隐藏弹层，但不主动重置当前打开状态。                       | `boolean`                                 | `false`            |
 | focusDelay                 | `focus` 后显示前的延迟，单位为秒。                                | `number`                                  | -                  |
 | forceRender                | 首次显示前渲染弹层。                                    | `boolean`                                 | `false`            |
 | fresh                      | 关闭时仍保持弹层内容更新。                                  | `boolean`                                 | -                  |

--- a/docs/demos/disabled.md
+++ b/docs/demos/disabled.md
@@ -1,0 +1,8 @@
+---
+title: Disabled
+nav:
+  title: Demo
+  path: /demo
+---
+
+<code src="../examples/disabled.tsx"></code>

--- a/docs/examples/disabled.tsx
+++ b/docs/examples/disabled.tsx
@@ -1,0 +1,38 @@
+import Trigger from '@rc-component/trigger';
+import React, { useState } from 'react';
+import '../../assets/index.less';
+
+const builtinPlacements = {
+  top: {
+    points: ['bc', 'tc'],
+    offset: [0, -8],
+  },
+};
+
+const DisabledDemo = () => {
+  const [disabled, setDisabled] = useState(false);
+
+  return (
+    <div style={{ padding: 100 }}>
+      <Trigger
+        action="hover"
+        builtinPlacements={builtinPlacements}
+        disabled={disabled}
+        popup={<span>Tooltip content</span>}
+        popupPlacement="top"
+        popupStyle={{
+          padding: '6px 8px',
+          color: '#fff',
+          background: '#1f1f1f',
+          borderRadius: 4,
+        }}
+      >
+        <button type="button" onClick={() => setDisabled((value) => !value)}>
+          {disabled ? 'Enable Tooltip' : 'Disable Tooltip'}
+        </button>
+      </Trigger>
+    </div>
+  );
+};
+
+export default DisabledDemo;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -65,6 +65,8 @@ export interface TriggerProps {
   action?: ActionType | ActionType[];
   showAction?: ActionType[];
   hideAction?: ActionType[];
+  /** Temporarily suppress popup visibility without resetting the current open state. */
+  disabled?: boolean;
 
   prefixCls?: string;
 
@@ -159,6 +161,7 @@ export function generateTrigger(
       action = 'hover',
       showAction,
       hideAction,
+      disabled = false,
 
       // Open
       popupVisible,
@@ -319,7 +322,7 @@ export function generateTrigger(
       popupVisible,
     );
 
-    const mergedOpen = internalOpen || false;
+    const mergedOpen = (internalOpen || false) && !disabled;
 
     // ========================== Children ==========================
     const child = React.useMemo(() => {

--- a/tests/basic.test.jsx
+++ b/tests/basic.test.jsx
@@ -179,6 +179,35 @@ describe('Trigger.Basic', () => {
         trigger(document, '.rc-trigger-popup', 'pointerEnter');
         expect(isPopupHidden()).toBeFalsy();
       });
+
+      it('temporarily hides while disabled and restores without mouse leave', () => {
+        const onOpenChange = jest.fn();
+        const Demo = ({ disabled = false }) => (
+          <Trigger
+            action={['hover']}
+            disabled={disabled}
+            onOpenChange={onOpenChange}
+            popup={<strong>trigger</strong>}
+          >
+            <div className="target">hover</div>
+          </Trigger>
+        );
+
+        const { container, rerender } = render(<Demo />);
+
+        trigger(container, '.target', 'mouseEnter');
+        expect(isPopupHidden()).toBeFalsy();
+        expect(onOpenChange).toHaveBeenCalledWith(true);
+        onOpenChange.mockReset();
+
+        rerender(<Demo disabled />);
+        expect(isPopupHidden()).toBeTruthy();
+        expect(onOpenChange).not.toHaveBeenCalled();
+
+        rerender(<Demo />);
+        expect(isPopupHidden()).toBeFalsy();
+        expect(onOpenChange).not.toHaveBeenCalled();
+      });
     });
 
     it('contextMenu works', () => {
@@ -1007,6 +1036,34 @@ describe('Trigger.Basic', () => {
     );
 
     expect(document.querySelector('.rc-trigger-popup')).toBeTruthy();
+  });
+
+  it('temporarily hides a controlled popup without changing its open state', () => {
+    const onOpenChange = jest.fn();
+    const Demo = ({ disabled = false }) => (
+      <Trigger
+        disabled={disabled}
+        onOpenChange={onOpenChange}
+        popup={<strong>trigger</strong>}
+        popupVisible
+      >
+        {({ open }) => <div data-open={open} />}
+      </Trigger>
+    );
+
+    const { container, rerender } = render(<Demo />);
+
+    expect(container.firstChild).toHaveAttribute('data-open', 'true');
+    expect(isPopupHidden()).toBeFalsy();
+
+    rerender(<Demo disabled />);
+    expect(container.firstChild).toHaveAttribute('data-open', 'false');
+    expect(isPopupHidden()).toBeTruthy();
+
+    rerender(<Demo />);
+    expect(container.firstChild).toHaveAttribute('data-open', 'true');
+    expect(isPopupHidden()).toBeFalsy();
+    expect(onOpenChange).not.toHaveBeenCalled();
   });
 
   describe('click window to hide', () => {


### PR DESCRIPTION
## Summary

- add a `disabled` prop that masks effective popup visibility while preserving the existing controlled or uncontrolled open state
- add a hover Tooltip demo whose Button toggles `disabled` on click
- document the new prop in English and Chinese

## Behavior

When a hover-triggered popup is already open, setting `disabled` hides it immediately. Setting `disabled` back to `false` restores it while the existing open state remains active, without requiring another mouse enter.

`disabled` only affects `mergedOpen`; it does not add separate event guards, effects, open-state storage, or `UniqueProvider` state.

Related: https://github.com/ant-design/ant-design/issues/57290

## Validation

- `ut coverage --runInBand` (17 suites, 132 passed, 1 skipped)
- `ut tsc`
- `ut docs:build`
- `ut x prettier@3.9.4 --check docs/examples/disabled.tsx docs/demos/disabled.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增 `disabled` 配置，可暂时隐藏弹层，同时保留当前打开状态。
  * 提供禁用与恢复 Tooltip 显示的示例。

* **文档**
  * 更新中英文 API 文档，补充 `disabled` 配置说明及默认值。
  * 新增禁用 Tooltip 的演示页面。

* **测试**
  * 增加悬浮触发和受控模式下的禁用行为测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->