### PR TITLE
fix: update open state while disabled

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -21,4 +21,4 @@ jobs:
           persist-credentials: false
       - uses: millionco/react-doctor@0b4f4f4bd248a154e64eb508a48347f71154b3f3
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 0.7.4

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -322,7 +322,8 @@ export function generateTrigger(
       popupVisible,
     );
 
-    const mergedOpen = (internalOpen || false) && !disabled;
+    const rawOpen = internalOpen || false;
+    const mergedOpen = rawOpen && !disabled;
 
     // ========================== Children ==========================
     const child = React.useMemo(() => {
@@ -387,7 +388,7 @@ export function generateTrigger(
 
     const internalTriggerOpen = useEvent((nextOpen: boolean) => {
       flushSync(() => {
-        if (mergedOpen !== nextOpen) {
+        if (rawOpen !== nextOpen) {
           setInternalOpen(nextOpen);
           onOpenChange?.(nextOpen);
           onPopupVisibleChange?.(nextOpen);

--- a/tests/basic.test.jsx
+++ b/tests/basic.test.jsx
@@ -208,6 +208,35 @@ describe('Trigger.Basic', () => {
         expect(isPopupHidden()).toBeFalsy();
         expect(onOpenChange).not.toHaveBeenCalled();
       });
+
+      it('updates open state when mouse leaves while disabled', () => {
+        const onOpenChange = jest.fn();
+        const Demo = ({ disabled = false }) => (
+          <Trigger
+            action={['hover']}
+            disabled={disabled}
+            onOpenChange={onOpenChange}
+            popup={<strong>trigger</strong>}
+          >
+            <div className="target">hover</div>
+          </Trigger>
+        );
+
+        const { container, rerender } = render(<Demo />);
+
+        trigger(container, '.target', 'mouseEnter');
+        expect(isPopupHidden()).toBeFalsy();
+        onOpenChange.mockReset();
+
+        rerender(<Demo disabled />);
+        expect(isPopupHidden()).toBeTruthy();
+
+        trigger(container, '.target', 'mouseLeave');
+        expect(onOpenChange).toHaveBeenCalledWith(false);
+
+        rerender(<Demo />);
+        expect(isPopupHidden()).toBeTruthy();
+      });
     });
 
     it('contextMenu works', () => {


### PR DESCRIPTION
Follow up #638

## Summary
- separate the raw open state from the disabled merged state
- update the raw open state when hover leaves while disabled
- prevent the popup from reopening after disabled is removed when the pointer has already left

## Tests
- `ut test --runInBand`
- `ut tsc`
- `ut lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 修复触发器在悬停打开后切换为禁用，再触发离开鼠标时，受控/受管打开状态未能正确同步的问题。
  * 恢复启用后，弹出层保持隐藏，避免因状态更新导致的意外重新显示。
* **测试**
  * 新增“禁用时离开鼠标并恢复启用后不自动弹出”的用例，覆盖该状态流转场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->